### PR TITLE
Redesign/fixtures

### DIFF
--- a/app/components/DatePicker.vue
+++ b/app/components/DatePicker.vue
@@ -1,0 +1,101 @@
+<template>
+  <div class="flex items-center gap-1">
+    <UButton icon="i-lucide-chevron-left" size="xs" color="secondary" variant="soft" @click="goPrev" />
+
+    <UPopover v-model:open="popoverOpen" :popper="{ placement: 'bottom' }">
+      <UButton
+        :label="modelValue ? formatDate(modelValue) : ''"
+        size="xs"
+        color="secondary"
+        variant="soft"
+        class="w-28 justify-center"
+      />
+
+      <template #content>
+        <UCalendar v-model="calendarValue" :max-value="maxCalendar" @update:model-value="onCalendarSelect" />
+      </template>
+    </UPopover>
+
+    <UButton
+      icon="i-lucide-chevron-right"
+      size="xs"
+      color="secondary"
+      variant="soft"
+      :disabled="isAtMax"
+      @click="goNext"
+    />
+  </div>
+</template>
+
+<script setup>
+import { CalendarDate } from '@internationalized/date'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  maxValue: { type: String, default: '' },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+function isoToCalendarDate(iso) {
+  if (!iso) return null
+  const [y, m, d] = iso.split('-').map(Number)
+  return new CalendarDate(y, m, d)
+}
+
+function calendarDateToIso(cal) {
+  if (!cal) return ''
+  return `${cal.year}-${String(cal.month).padStart(2, '0')}-${String(cal.day).padStart(2, '0')}`
+}
+
+function todayIso() {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const calendarValue = ref(isoToCalendarDate(props.modelValue))
+const maxCalendar = computed(() => isoToCalendarDate(props.maxValue) || isoToCalendarDate(todayIso()))
+const popoverOpen = ref(false)
+
+const isAtMax = computed(() => {
+  if (!calendarValue.value) return false
+  return calendarDateToIso(calendarValue.value) === (props.maxValue || todayIso())
+})
+
+function onCalendarSelect(newCal) {
+  if (!newCal) return
+  calendarValue.value = newCal
+  emit('update:modelValue', calendarDateToIso(newCal))
+  popoverOpen.value = false
+}
+
+function goPrev() {
+  if (!calendarValue.value) return
+  const cur = calendarValue.value
+  const d = new Date(cur.year, cur.month - 1, cur.day - 1)
+  const newCal = new CalendarDate(d.getFullYear(), d.getMonth() + 1, d.getDate())
+  calendarValue.value = newCal
+  emit('update:modelValue', calendarDateToIso(newCal))
+}
+
+function goNext() {
+  if (!calendarValue.value) return
+  if (isAtMax.value) return
+  const cur = calendarValue.value
+  const d = new Date(cur.year, cur.month - 1, cur.day + 1)
+  const newCal = new CalendarDate(d.getFullYear(), d.getMonth() + 1, d.getDate())
+  calendarValue.value = newCal
+  emit('update:modelValue', calendarDateToIso(newCal))
+}
+
+watch(
+  () => props.modelValue,
+  (newIso) => {
+    if (!newIso) return
+    const newCal = isoToCalendarDate(newIso)
+    if (newCal && (!calendarValue.value || calendarDateToIso(calendarValue.value) !== newIso)) {
+      calendarValue.value = newCal
+    }
+  },
+)
+</script>

--- a/app/components/SegmentedControl.vue
+++ b/app/components/SegmentedControl.vue
@@ -5,7 +5,11 @@
       :key="opt.value"
       type="button"
       class="rounded-md px-3 py-1 text-sm transition"
-      :class="opt.value === modelValue ? 'bg-teal-500 text-zinc-950' : 'text-zinc-400 hover:text-white'"
+      :class="
+        opt.value === modelValue
+          ? 'bg-teal-500 font-semibold text-zinc-950'
+          : 'font-medium text-zinc-400 hover:text-white'
+      "
       @click="emit('update:modelValue', opt.value)"
     >
       {{ opt.label }}
@@ -15,7 +19,7 @@
 
 <script setup>
 defineProps({
-  modelValue: { type: String, default: '' },
+  modelValue: { type: String, required: true },
   options: {
     type: Array,
     required: true,

--- a/app/components/SegmentedControl.vue
+++ b/app/components/SegmentedControl.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="inline-flex items-center gap-1 rounded-lg border border-zinc-800 bg-zinc-900 p-1">
+    <button
+      v-for="opt in options"
+      :key="opt.value"
+      type="button"
+      class="rounded-md px-3 py-1 text-sm transition"
+      :class="opt.value === modelValue ? 'bg-teal-500 text-zinc-950' : 'text-zinc-400 hover:text-white'"
+      @click="emit('update:modelValue', opt.value)"
+    >
+      {{ opt.label }}
+    </button>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  modelValue: { type: String, default: '' },
+  options: {
+    type: Array,
+    required: true,
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+</script>

--- a/app/components/fixtureCard.vue
+++ b/app/components/fixtureCard.vue
@@ -4,7 +4,7 @@
       v-for="item in internalFixtures"
       :key="item._id"
       class="fixture-card mb-2 flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-4 hover:border-zinc-700 sm:gap-5 sm:px-6"
-      :class="item._id === chosen._id ? 'border-1 border-teal-400 sm:border' : ''"
+      :class="item._id === chosen._id ? 'border border-teal-400 sm:border' : ''"
       @click="emits('click', item)"
     >
       <div class="flex items-center gap-7">
@@ -22,15 +22,15 @@
           <div>{{ item.Home }} x {{ item.Away }}</div>
 
           <div class="flex gap-1">
-            <UBadge color="primary" variant="soft">
+            <UBadge :color="item.FT_Odds_H < item.FT_Odds_A ? 'primary' : 'neutral'" variant="soft">
               {{ item.FT_Odds_H.toFixed(2) }}
             </UBadge>
 
-            <UBadge color="primary" variant="soft">
+            <UBadge color="neutral" variant="soft">
               {{ item.FT_Odds_D.toFixed(2) }}
             </UBadge>
 
-            <UBadge color="primary" variant="soft">
+            <UBadge :color="item.FT_Odds_A < item.FT_Odds_H ? 'primary' : 'neutral'" variant="soft">
               {{ item.FT_Odds_A.toFixed(2) }}
             </UBadge>
           </div>

--- a/app/components/fixtureCard.vue
+++ b/app/components/fixtureCard.vue
@@ -13,7 +13,7 @@
             {{ item.Time }}
           </div>
 
-          <div class="text-xs text-zinc-500 sm:text-sm">
+          <div class="text-xs text-zinc-500">
             {{ formatDate(item.Date) }}
           </div>
         </div>

--- a/app/components/fixtureCard.vue
+++ b/app/components/fixtureCard.vue
@@ -3,7 +3,7 @@
     <div
       v-for="item in internalFixtures"
       :key="item._id"
-      class="mb-2 flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-4 hover:border-zinc-700 sm:gap-5 sm:px-6"
+      class="fixture-card mb-2 flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-4 hover:border-zinc-700 sm:gap-5 sm:px-6"
       :class="item._id === chosen._id ? 'border-1 border-teal-400 sm:border' : ''"
       @click="emits('click', item)"
     >
@@ -84,4 +84,22 @@ function countModels(fixture) {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style scoped>
+.fixture-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.fixture-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.08), transparent);
+  transition: transform 0.6s ease;
+}
+
+.fixture-card:hover::after {
+  transform: translateX(100%);
+}
+</style>

--- a/app/components/fixtureCard.vue
+++ b/app/components/fixtureCard.vue
@@ -3,8 +3,8 @@
     <div
       v-for="item in internalFixtures"
       :key="item._id"
-      class="mb-2 flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-gray-700 bg-slate-900 px-4 py-4 hover:border-teal-400 sm:gap-5 sm:px-6"
-      :class="item._id === chosen._id ? 'border-1 sm:border sm:border-teal-400' : ''"
+      class="mb-2 flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-4 hover:border-zinc-700 sm:gap-5 sm:px-6"
+      :class="item._id === chosen._id ? 'border-1 border-teal-400 sm:border' : ''"
       @click="emits('click', item)"
     >
       <div class="flex items-center gap-7">
@@ -13,7 +13,7 @@
             {{ item.Time }}
           </div>
 
-          <div class="text-xs text-gray-500 sm:text-sm">
+          <div class="text-xs text-zinc-500 sm:text-sm">
             {{ formatDate(item.Date) }}
           </div>
         </div>
@@ -22,15 +22,15 @@
           <div>{{ item.Home }} x {{ item.Away }}</div>
 
           <div class="flex gap-1">
-            <UBadge :color="item.FT_Odds_H < item.FT_Odds_A ? 'primary' : 'neutral'" variant="soft">
+            <UBadge color="primary" variant="soft">
               {{ item.FT_Odds_H.toFixed(2) }}
             </UBadge>
 
-            <UBadge color="neutral" variant="soft">
+            <UBadge color="primary" variant="soft">
               {{ item.FT_Odds_D.toFixed(2) }}
             </UBadge>
 
-            <UBadge :color="item.FT_Odds_A < item.FT_Odds_H ? 'primary' : 'error'" variant="soft">
+            <UBadge color="primary" variant="soft">
               {{ item.FT_Odds_A.toFixed(2) }}
             </UBadge>
           </div>
@@ -38,11 +38,11 @@
       </div>
 
       <div class="flex min-w-16 flex-col items-end gap-1 text-end">
-        <div class="text-xs text-gray-600">Entrada em</div>
+        <div class="text-xs text-zinc-500">Entrada em</div>
 
-        <div v-if="countModels(item) === 0" class="text-xs font-semibold text-gray-500 sm:text-sm">Nenhum</div>
+        <div v-if="countModels(item) === 0" class="text-xs font-semibold text-zinc-500 sm:text-sm">Nenhum</div>
 
-        <div v-else class="text-xs font-semibold text-gray-500 sm:text-sm">
+        <div v-else class="text-xs font-semibold text-teal-500 sm:text-sm">
           {{ countModels(item) }} {{ countModels(item) === 1 ? 'modelo' : 'modelos' }}
         </div>
       </div>

--- a/app/components/fixtureCard.vue
+++ b/app/components/fixtureCard.vue
@@ -3,7 +3,7 @@
     <div
       v-for="item in internalFixtures"
       :key="item._id"
-      class="fixture-card mb-2 flex w-full cursor-pointer items-center justify-between gap-3 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-4 hover:border-zinc-700 sm:gap-5 sm:px-6"
+      class="fixture-card mb-2 flex w-full cursor-pointer items-center justify-between gap-3 rounded-2xl border border-zinc-800 bg-zinc-900 px-4 py-4 hover:border-zinc-700 sm:gap-5 sm:px-6"
       :class="item._id === chosen._id ? 'border border-teal-400 sm:border' : ''"
       @click="emits('click', item)"
     >

--- a/app/components/fixtureDetailsCard.vue
+++ b/app/components/fixtureDetailsCard.vue
@@ -1,71 +1,83 @@
 <template>
   <div class="relative flex w-full flex-col gap-3">
-    <div class="flex justify-center text-sm text-gray-500 sm:text-base">
-      {{ fixture.Date ? formatDate(fixture.Date) : '' }} - {{ fixture?.Time }}
-    </div>
+    <div class="flex flex-col items-center gap-1 text-sm text-zinc-300 sm:text-base">
+      <span>{{ fixture.Date ? formatDate(fixture.Date) : '' }} - {{ fixture?.Time }}</span>
 
-    <div class="-mt-3 flex justify-center text-sm text-gray-500">
-      {{ fixture?.League || '' }}
+      <span>{{ fixture?.League || '' }}</span>
     </div>
 
     <div class="mt-2 flex justify-center text-lg font-semibold sm:mt-0 sm:text-2xl">
       {{ fixture?.Home }} x {{ fixture?.Away }}
     </div>
 
-    <div class="flex justify-center gap-1">
-      <UBadge color="primary" variant="soft" size="md">
-        {{ isMobile ? 'H' : 'Home' }}: {{ fixture?.FT_Odds_H?.toFixed(2) }}
-      </UBadge>
+    <div class="mt-2 flex flex-col gap-2">
+      <div class="rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2">
+        <p class="text-xs text-zinc-300">H / D / A</p>
 
-      <UBadge color="primary" variant="soft" size="md">
-        {{ isMobile ? 'D' : 'Draw' }}: {{ fixture?.FT_Odds_D?.toFixed(2) }}
-      </UBadge>
+        <div class="mt-1 flex items-center gap-2 text-sm">
+          <span class="font-semibold text-white">H</span>
 
-      <UBadge color="primary" variant="soft" size="md">
-        {{ isMobile ? 'A' : 'Away' }}: {{ fixture?.FT_Odds_A?.toFixed(2) }}
-      </UBadge>
-    </div>
+          <span class="text-white">{{ fixture?.FT_Odds_H?.toFixed(2) }}</span>
 
-    <div class="mt-3 mb-2 flex items-center justify-between gap-3 text-center text-lg font-semibold">
-      <div class="flex w-1/2 flex-col items-center gap-2">
-        <div>Over 2.5</div>
+          <span class="text-zinc-500">·</span>
 
-        <div class="flex items-center gap-2">
-          <UBadge color="primary" variant="soft" size="md" class="w-fit">
-            {{ isMobile ? 'O' : 'Over' }}: {{ fixture?.Odds_O25?.toFixed(2) }}
-          </UBadge>
+          <span class="font-semibold text-white">D</span>
 
-          <UBadge color="primary" variant="soft" size="md" class="w-fit">
-            {{ isMobile ? 'U' : 'Under' }}: {{ fixture?.Odds_U25?.toFixed(2) }}
-          </UBadge>
+          <span class="text-white">{{ fixture?.FT_Odds_D?.toFixed(2) }}</span>
+
+          <span class="text-zinc-500">·</span>
+
+          <span class="font-semibold text-white">A</span>
+
+          <span class="text-white">{{ fixture?.FT_Odds_A?.toFixed(2) }}</span>
         </div>
       </div>
 
-      <div class="flex w-1/2 flex-col items-center gap-2">
-        <div>BTTS</div>
+      <div class="grid grid-cols-2 gap-2">
+        <div class="rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2">
+          <p class="text-xs text-zinc-300">O/U 2.5</p>
 
-        <div class="flex items-center gap-2">
-          <UBadge color="primary" variant="soft" size="md" class="w-fit">
-            {{ isMobile ? 'Y' : 'Yes' }}: {{ fixture?.BTTS_Yes?.toFixed(2) }}
-          </UBadge>
+          <div class="mt-1 flex items-center gap-2 text-sm">
+            <span class="font-semibold text-white">O</span>
 
-          <UBadge color="primary" variant="soft" size="md" class="w-fit">
-            {{ isMobile ? 'N' : 'No' }}: {{ fixture?.BTTS_No?.toFixed(2) }}
-          </UBadge>
+            <span class="text-white">{{ fixture?.Odds_O25?.toFixed(2) }}</span>
+
+            <span class="text-zinc-500">·</span>
+
+            <span class="font-semibold text-white">U</span>
+
+            <span class="text-white">{{ fixture?.Odds_U25?.toFixed(2) }}</span>
+          </div>
+        </div>
+
+        <div class="rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2">
+          <p class="text-xs text-zinc-300">BTTS</p>
+
+          <div class="mt-1 flex items-center gap-2 text-sm">
+            <span class="font-semibold text-white">Y</span>
+
+            <span class="text-white">{{ fixture?.BTTS_Yes?.toFixed(2) }}</span>
+
+            <span class="text-zinc-500">·</span>
+
+            <span class="font-semibold text-white">N</span>
+
+            <span class="text-white">{{ fixture?.BTTS_No?.toFixed(2) }}</span>
+          </div>
         </div>
       </div>
     </div>
 
-    <div class="mt-6 w-full">
-      <div class="mb-3 flex flex-col gap-2 text-sm">
+    <div class="mt-6 w-full border-t border-zinc-800 pt-4">
+      <div class="mb-3 flex flex-col gap-2 text-sm text-zinc-300">
         {{
           fixtureAllowedModels.length > 0
-            ? 'Modelos com entrada para este jogo: '
+            ? 'Modelos com entrada para este jogo:'
             : 'Nenhum modelo com entrada para este jogo.'
         }}
       </div>
 
-      <div v-for="model in fixtureAllowedModels" :key="model" class="mb-1">• {{ model }}</div>
+      <div v-for="model in fixtureAllowedModels" :key="model" class="mb-1 text-sm text-zinc-300">• {{ model }}</div>
     </div>
   </div>
 </template>
@@ -81,8 +93,6 @@ const props = defineProps({
     required: true,
   },
 })
-
-const { isMobile } = useDevice()
 
 const fixtureAllowedModels = computed(() => {
   return props.bets.map((item) => modelNameToNaturalName(item.Modelo))

--- a/app/components/fixtureDetailsCard.vue
+++ b/app/components/fixtureDetailsCard.vue
@@ -11,7 +11,7 @@
     </div>
 
     <div class="mt-2 flex flex-col gap-2">
-      <div class="rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2">
+      <div class="rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2">
         <p class="text-xs text-zinc-300">Match odds</p>
 
         <div class="mt-1 flex items-center gap-2 text-sm">
@@ -40,7 +40,7 @@
       </div>
 
       <div class="grid grid-cols-2 gap-2">
-        <div class="rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2">
+        <div class="rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2">
           <p class="text-xs text-zinc-300">O/U 2.5</p>
 
           <div class="mt-1 flex items-center gap-2 text-sm">
@@ -56,7 +56,7 @@
           </div>
         </div>
 
-        <div class="rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2">
+        <div class="rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2">
           <p class="text-xs text-zinc-300">BTTS</p>
 
           <div class="mt-1 flex items-center gap-2 text-sm">

--- a/app/components/fixtureDetailsCard.vue
+++ b/app/components/fixtureDetailsCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative flex w-full flex-col gap-3">
-    <div class="flex flex-col items-center gap-1 text-sm text-zinc-300 sm:text-base">
-      <span>{{ fixture.Date ? formatDate(fixture.Date) : '' }} - {{ fixture?.Time }}</span>
+    <div class="flex flex-col items-center text-sm text-zinc-300">
+      <span> {{ fixture.Date ? formatDate(fixture.Date) : '' }} - {{ fixture?.Time }} </span>
 
       <span>{{ fixture?.League || '' }}</span>
     </div>
@@ -12,24 +12,30 @@
 
     <div class="mt-2 flex flex-col gap-2">
       <div class="rounded-md border border-zinc-800 bg-zinc-900 px-3 py-2">
-        <p class="text-xs text-zinc-300">H / D / A</p>
+        <p class="text-xs text-zinc-300">Match odds</p>
 
         <div class="mt-1 flex items-center gap-2 text-sm">
           <span class="font-semibold text-white">H</span>
 
-          <span class="text-white">{{ fixture?.FT_Odds_H?.toFixed(2) }}</span>
+          <span class="text-white">
+            {{ fixture?.FT_Odds_H?.toFixed(2) }}
+          </span>
 
           <span class="text-zinc-500">·</span>
 
           <span class="font-semibold text-white">D</span>
 
-          <span class="text-white">{{ fixture?.FT_Odds_D?.toFixed(2) }}</span>
+          <span class="text-white">
+            {{ fixture?.FT_Odds_D?.toFixed(2) }}
+          </span>
 
           <span class="text-zinc-500">·</span>
 
           <span class="font-semibold text-white">A</span>
 
-          <span class="text-white">{{ fixture?.FT_Odds_A?.toFixed(2) }}</span>
+          <span class="text-white">
+            {{ fixture?.FT_Odds_A?.toFixed(2) }}
+          </span>
         </div>
       </div>
 

--- a/app/components/fixturesList.vue
+++ b/app/components/fixturesList.vue
@@ -1,15 +1,15 @@
 <template>
   <div>
-    <div class="mb-4 flex items-baseline gap-2 sm:gap-5">
-      <USelectMenu v-model="chosenDay" class="w-1/2 sm:w-1/5" placeholder="Selecione um dia" :options="datesOptions" />
+    <div class="mb-4 flex flex-wrap items-center gap-2 sm:gap-5">
+      <DatePicker v-model="chosenDay" />
 
-      <UTabs :items="tabItems" @change="onTabChange" />
+      <SegmentedControl v-model="selectedTab" :options="tabItems" />
     </div>
 
     <FixturesListSkeleton v-if="loading" />
 
     <div v-else>
-      <div class="mb-3 text-sm">{{ internalFixtures.length }} jogos</div>
+      <div class="mb-3 text-sm text-zinc-400">{{ internalFixtures.length }} jogos</div>
 
       <div class="flex gap-3">
         <div class="w-full sm:w-1/2">
@@ -25,24 +25,21 @@
         <div v-if="!$device.isMobile" class="sticky top-4 h-full w-1/2">
           <div
             v-if="!chosenGame._id"
-            class="flex h-[50svh] w-full items-center justify-center rounded-md p-10 outline-1 outline-gray-400 outline-dashed"
+            class="flex h-[50svh] w-full flex-col items-center justify-center gap-2 rounded-md p-10 outline-1 outline-zinc-800 outline-dashed"
           >
-            <p class="text-center text-2xl text-gray-400">
-              Selecione um card ao lado para ver informações sobre o jogo
-            </p>
+            <UIcon name="i-lucide-mouse-pointer-click" class="text-2xl text-zinc-500" />
+
+            <p class="text-center text-sm text-zinc-500">Selecione um card ao lado para ver informações sobre o jogo</p>
           </div>
 
           <div
             v-else-if="showSkeleton"
-            class="flex h-[50svh] w-full items-center justify-center rounded-md bg-slate-800 p-10 outline-1 outline-slate-900 outline-dashed"
+            class="flex h-[50svh] w-full items-center justify-center rounded-md bg-zinc-800 p-10"
           >
-            <p class="text-center text-sm text-gray-400">Carregando...</p>
+            <p class="text-center text-sm text-zinc-400">Carregando...</p>
           </div>
 
-          <div
-            v-else
-            class="flex w-full justify-center rounded-md bg-slate-900 p-10 outline outline-1 outline-slate-700"
-          >
+          <div v-else class="flex w-full justify-center rounded-md bg-zinc-900 p-10 outline outline-1 outline-zinc-800">
             <FixtureDetailsCard :fixture="chosenGame" :bets="filteredBets" />
           </div>
         </div>
@@ -50,7 +47,7 @@
     </div>
 
     <UModal v-if="isMobile" v-model="showMobileModal">
-      <div class="border-opacity-40 flex h-[60vh] flex-col gap-3 rounded-lg border border-teal-500 bg-slate-900 p-5">
+      <div class="flex h-[60vh] flex-col gap-3 rounded-lg border border-teal-500 bg-zinc-900 p-5">
         <div v-if="_isEmpty(chosenGame)" class="flex flex-col items-center gap-2">
           <USkeleton class="h-5 w-1/2" />
 
@@ -64,9 +61,7 @@
         <FixtureDetailsCard v-else :fixture="chosenGame" :bets="filteredBets" />
 
         <div class="absolute right-0 bottom-0 left-0 p-4">
-          <UButton block color="teal" variant="soft" size="lg" @click="() => (showMobileModal = false)">
-            Fechar
-          </UButton>
+          <UButton block color="teal" size="lg" @click="() => (showMobileModal = false)"> Fechar </UButton>
         </div>
       </div>
     </UModal>
@@ -102,36 +97,18 @@ const props = defineProps({
 const emits = defineEmits(['change', 'source-change'])
 
 const tabItems = [
-  {
-    label: 'Exchange',
-    value: 'exchange',
-  },
-  {
-    label: 'Bookie',
-    value: 'bookie',
-  },
+  { label: 'Exchange', value: 'exchange' },
+  { label: 'Bookie', value: 'bookie' },
 ]
 
 const internalFixtures = ref([])
-const chosenDay = ref(props.selectedDate || formatDate(new Date().toISOString().split('T')[0]))
+const chosenDay = ref(props.selectedDate || new Date().toISOString().split('T')[0])
 const chosenGame = ref({})
 const filteredBets = ref([])
 const selectedTab = ref('exchange')
 const betfairFixtures = ref(true)
 const showSkeleton = ref(false)
 const showMobileModal = ref(false)
-
-const datesOptions = computed(() => {
-  const dates = []
-  const currentDate = props.initialDate ? new Date(props.initialDate) : new Date()
-
-  for (let i = 0; i < 7; i++) {
-    const virtualDate = new Date(currentDate.getTime() - i * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
-    dates.push(formatDate(virtualDate))
-  }
-
-  return dates
-})
 
 watch(
   () => props.fixtures,
@@ -149,7 +126,8 @@ watch(
   },
 )
 
-watch(betfairFixtures, () => {
+watch(selectedTab, (value) => {
+  betfairFixtures.value = value !== 'bookie'
   emits('source-change', betfairFixtures.value)
 })
 
@@ -163,15 +141,6 @@ watch(
     }
   },
 )
-
-function onTabChange(tab) {
-  selectedTab.value = tabItems[tab].value
-  if (selectedTab.value === 'bookie') {
-    betfairFixtures.value = false
-  } else {
-    betfairFixtures.value = true
-  }
-}
 
 async function handleGameClick(game) {
   showMobileModal.value = true

--- a/app/components/fixturesList.vue
+++ b/app/components/fixturesList.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
-    <div class="mb-4 flex flex-wrap items-center justify-between gap-2 sm:gap-5">
+    <div class="mb-4 flex flex-wrap items-center gap-2 sm:gap-5">
       <SegmentedControl v-model="selectedTab" :options="tabItems" />
-
-      <p class="text-sm text-zinc-400">{{ internalFixtures.length }} jogos</p>
     </div>
 
     <FixturesListSkeleton v-if="loading" />
 
     <div v-else>
+      <div class="mb-3 text-sm text-zinc-400">{{ internalFixtures.length }} jogos</div>
+
       <div class="flex gap-3">
         <div class="w-full sm:w-1/2">
           <FixtureCard

--- a/app/components/fixturesList.vue
+++ b/app/components/fixturesList.vue
@@ -3,7 +3,7 @@
     <FixturesListSkeleton v-if="loading" />
 
     <div v-else>
-      <div class="mb-4 flex items-center justify-between gap-2 sm:gap-3">
+      <div class="mb-4 flex w-full items-center justify-between gap-2 sm:w-1/2 sm:gap-3">
         <p class="text-sm text-zinc-400">{{ internalFixtures.length }} jogos</p>
 
         <SegmentedControl v-model="selectedTab" :options="tabItems" />

--- a/app/components/fixturesList.vue
+++ b/app/components/fixturesList.vue
@@ -3,14 +3,14 @@
     <FixturesListSkeleton v-if="loading" />
 
     <div v-else>
-      <div class="mb-4 flex w-full items-center justify-between gap-2 sm:w-1/2 sm:gap-3">
+      <div class="mb-4 flex w-full items-center justify-between gap-2 gap-3 lg:w-1/2">
         <p class="text-sm text-zinc-400">{{ internalFixtures.length }} jogos</p>
 
         <SegmentedControl v-model="selectedTab" :options="tabItems" />
       </div>
 
       <div class="flex gap-3">
-        <div class="w-full sm:w-1/2">
+        <div class="w-full lg:w-1/2">
           <FixtureCard
             class="w-full"
             :fixtures="internalFixtures"
@@ -20,7 +20,7 @@
           />
         </div>
 
-        <div v-if="!$device.isMobile" class="sticky top-4 h-full w-1/2">
+        <div v-if="!isNarrow" class="sticky top-4 h-full w-1/2">
           <div
             v-if="!chosenGame._id"
             class="flex h-[50svh] w-full flex-col items-center justify-center gap-2 rounded-2xl p-10 outline-1 outline-zinc-800 outline-dashed"
@@ -28,13 +28,6 @@
             <UIcon name="i-lucide-mouse-pointer-click" class="text-2xl text-zinc-500" />
 
             <p class="text-center text-sm text-zinc-500">Selecione um card ao lado para ver informações sobre o jogo</p>
-          </div>
-
-          <div
-            v-else-if="showSkeleton"
-            class="flex h-[50svh] w-full items-center justify-center rounded-2xl bg-zinc-800 p-10"
-          >
-            <p class="text-center text-sm text-zinc-400">Carregando...</p>
           </div>
 
           <div
@@ -47,30 +40,41 @@
       </div>
     </div>
 
-    <UModal v-if="isMobile" v-model="showMobileModal">
-      <div class="flex h-[60vh] flex-col gap-3 rounded-2xl border border-teal-500 bg-zinc-900 p-5">
-        <div v-if="_isEmpty(chosenGame)" class="flex flex-col items-center gap-2">
-          <USkeleton class="h-5 w-1/2" />
+    <UDrawer v-model:open="showMobileModal" :ui="{ content: 'bg-zinc-900' }">
+      <template #content>
+        <div class="flex flex-col gap-3 p-5">
+          <div v-if="!chosenGame._id" class="flex flex-col items-center gap-2 py-10">
+            <USkeleton class="h-5 w-1/2" />
 
-          <USkeleton class="h-5 w-28" />
+            <USkeleton class="h-5 w-28" />
 
-          <USkeleton class="mt-8 mb-6 h-16 w-3/4" />
+            <USkeleton class="mt-8 mb-6 h-16 w-3/4" />
 
-          <USkeleton v-for="i in 5" :key="i" class="mb-2 h-5 w-5/6" />
+            <USkeleton v-for="i in 5" :key="i" class="mb-2 h-5 w-5/6" />
+          </div>
+
+          <FixtureDetailsCard v-else :fixture="chosenGame" :bets="filteredBets" />
+
+          <div class="mt-auto pt-4">
+            <UButton block color="primary" variant="link" size="lg" @click="() => (showMobileModal = false)">
+              Fechar
+            </UButton>
+          </div>
         </div>
-
-        <FixtureDetailsCard v-else :fixture="chosenGame" :bets="filteredBets" />
-
-        <div class="absolute right-0 bottom-0 left-0 p-4">
-          <UButton block color="teal" size="lg" @click="() => (showMobileModal = false)"> Fechar </UButton>
-        </div>
-      </div>
-    </UModal>
+      </template>
+    </UDrawer>
   </div>
 </template>
 
 <script setup>
-const { isMobile } = useDevice()
+const isNarrow = ref(false)
+
+onMounted(() => {
+  isNarrow.value = window.innerWidth < 1024
+  window.addEventListener('resize', () => {
+    isNarrow.value = window.innerWidth < 1024
+  })
+})
 
 const props = defineProps({
   fixtures: {
@@ -99,7 +103,6 @@ const chosenGame = ref({})
 const filteredBets = ref([])
 const selectedTab = ref('exchange')
 const betfairFixtures = ref(true)
-const showSkeleton = ref(false)
 const showMobileModal = ref(false)
 
 watch(
@@ -127,20 +130,18 @@ watch(
 )
 
 async function handleGameClick(game) {
-  showMobileModal.value = true
-  showSkeleton.value = true
+  if (game._id === chosenGame.value._id) {
+    chosenGame.value = {}
+    showMobileModal.value = false
+    return
+  }
 
-  setTimeout(() => {
-    if (game._id === chosenGame.value._id) {
-      chosenGame.value = {}
-      return
-    }
+  chosenGame.value = game
+  filterBets()
 
-    chosenGame.value = game
-    filterBets()
-
-    showSkeleton.value = false
-  }, 100)
+  if (isNarrow.value) {
+    showMobileModal.value = true
+  }
 }
 
 function filterBets() {

--- a/app/components/fixturesList.vue
+++ b/app/components/fixturesList.vue
@@ -1,16 +1,14 @@
 <template>
   <div>
-    <div class="mb-4 flex flex-wrap items-center gap-2 sm:gap-5">
-      <DatePicker v-model="chosenDay" />
-
+    <div class="mb-4 flex flex-wrap items-center justify-between gap-2 sm:gap-5">
       <SegmentedControl v-model="selectedTab" :options="tabItems" />
+
+      <p class="text-sm text-zinc-400">{{ internalFixtures.length }} jogos</p>
     </div>
 
     <FixturesListSkeleton v-if="loading" />
 
     <div v-else>
-      <div class="mb-3 text-sm text-zinc-400">{{ internalFixtures.length }} jogos</div>
-
       <div class="flex gap-3">
         <div class="w-full sm:w-1/2">
           <FixtureCard
@@ -80,17 +78,13 @@ const props = defineProps({
     type: Array,
     required: true,
   },
-  selectedDate: {
-    type: String,
-    default: '',
-  },
   loading: {
     type: Boolean,
     default: false,
   },
 })
 
-const emits = defineEmits(['change', 'source-change'])
+const emits = defineEmits(['source-change'])
 
 const tabItems = [
   { label: 'Exchange', value: 'exchange' },
@@ -98,7 +92,6 @@ const tabItems = [
 ]
 
 const internalFixtures = ref([])
-const chosenDay = ref(props.selectedDate || new Date().toISOString().split('T')[0])
 const chosenGame = ref({})
 const filteredBets = ref([])
 const selectedTab = ref('exchange')
@@ -112,14 +105,6 @@ watch(
     internalFixtures.value = value.sort((a, b) => (a.Time > b.Time ? 1 : -1))
   },
   { immediate: true },
-)
-
-watch(
-  () => chosenDay.value,
-  (newValue, oldValue) => {
-    if (newValue === oldValue) return
-    emits('change', newValue)
-  },
 )
 
 watch(selectedTab, (value) => {

--- a/app/components/fixturesList.vue
+++ b/app/components/fixturesList.vue
@@ -23,7 +23,7 @@
         <div v-if="!$device.isMobile" class="sticky top-4 h-full w-1/2">
           <div
             v-if="!chosenGame._id"
-            class="flex h-[50svh] w-full flex-col items-center justify-center gap-2 rounded-md p-10 outline-1 outline-zinc-800 outline-dashed"
+            class="flex h-[50svh] w-full flex-col items-center justify-center gap-2 rounded-2xl p-10 outline-1 outline-zinc-800 outline-dashed"
           >
             <UIcon name="i-lucide-mouse-pointer-click" class="text-2xl text-zinc-500" />
 
@@ -32,12 +32,15 @@
 
           <div
             v-else-if="showSkeleton"
-            class="flex h-[50svh] w-full items-center justify-center rounded-md bg-zinc-800 p-10"
+            class="flex h-[50svh] w-full items-center justify-center rounded-2xl bg-zinc-800 p-10"
           >
             <p class="text-center text-sm text-zinc-400">Carregando...</p>
           </div>
 
-          <div v-else class="flex w-full justify-center rounded-md bg-zinc-900 p-10 outline outline-1 outline-zinc-800">
+          <div
+            v-else
+            class="flex w-full justify-center rounded-2xl bg-zinc-900 p-10 outline outline-1 outline-zinc-800"
+          >
             <FixtureDetailsCard :fixture="chosenGame" :bets="filteredBets" />
           </div>
         </div>
@@ -45,7 +48,7 @@
     </div>
 
     <UModal v-if="isMobile" v-model="showMobileModal">
-      <div class="flex h-[60vh] flex-col gap-3 rounded-lg border border-teal-500 bg-zinc-900 p-5">
+      <div class="flex h-[60vh] flex-col gap-3 rounded-2xl border border-teal-500 bg-zinc-900 p-5">
         <div v-if="_isEmpty(chosenGame)" class="flex flex-col items-center gap-2">
           <USkeleton class="h-5 w-1/2" />
 

--- a/app/components/fixturesList.vue
+++ b/app/components/fixturesList.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-    <div class="mb-4 flex flex-wrap items-center gap-2 sm:gap-5">
-      <SegmentedControl v-model="selectedTab" :options="tabItems" />
-    </div>
-
     <FixturesListSkeleton v-if="loading" />
 
     <div v-else>
-      <div class="mb-3 text-sm text-zinc-400">{{ internalFixtures.length }} jogos</div>
+      <div class="mb-4 flex items-center justify-between gap-2 sm:gap-3">
+        <p class="text-sm text-zinc-400">{{ internalFixtures.length }} jogos</p>
+
+        <SegmentedControl v-model="selectedTab" :options="tabItems" />
+      </div>
 
       <div class="flex gap-3">
         <div class="w-full sm:w-1/2">

--- a/app/components/fixturesList.vue
+++ b/app/components/fixturesList.vue
@@ -84,10 +84,6 @@ const props = defineProps({
     type: String,
     default: '',
   },
-  initialDate: {
-    type: String,
-    default: '',
-  },
   loading: {
     type: Boolean,
     default: false,

--- a/app/components/fixturesListSkeleton.vue
+++ b/app/components/fixturesListSkeleton.vue
@@ -1,17 +1,15 @@
 <template>
   <div>
-    <USkeleton class="h-[20px] w-[100px]" />
+    <USkeleton class="mb-4 h-5 w-25" />
 
-    <div class="mt-3.5 flex w-full gap-3">
-      <div class="flex w-1/2 flex-col gap-2">
-        <USkeleton v-for="i in 7" :key="i" class="h-[90px] w-full" />
+    <div class="flex gap-3">
+      <div class="flex w-full flex-col gap-2 sm:w-1/2">
+        <USkeleton v-for="i in 7" :key="i" class="h-22.5 w-full rounded-2xl" />
       </div>
 
-      <USkeleton class="h-[528px] w-1/2" />
+      <USkeleton class="hidden h-132 w-1/2 rounded-2xl sm:block" />
     </div>
   </div>
 </template>
 
 <script setup></script>
-
-<style lang="scss" scoped></style>

--- a/app/pages/fixtures.vue
+++ b/app/pages/fixtures.vue
@@ -6,74 +6,46 @@
       </template>
     </PageHeader>
 
-    <FixturesList :fixtures="fixturesToUse" :bets="bets" :loading="isLoading" @source-change="onSourceChange" />
+    <FixturesList :fixtures="fixtures" :bets="bets" :loading="isLoading" @source-change="onSourceChange" />
   </div>
 </template>
 
 <script setup>
-import { DateTime } from 'luxon'
-
 const apiUrl = useRuntimeConfig().public.API_URL
 
-const today = DateTime.now().toFormat('yyyy-MM-dd')
-const tomorrow = DateTime.now().plus({ days: 1 }).toFormat('yyyy-MM-dd')
 const selectedDate = ref('')
 const isLoading = ref(true)
-const betfairFixtures = ref(true)
+const source = ref('exchange')
+const fixtures = ref([])
+const bets = ref([])
 
-const fixturesToUse = ref([])
+const { data } = await useFetch(`${apiUrl}/fixtures/daily`, { params: { source: source.value } })
 
-const requests = [
-  useFetch(`${apiUrl}/fixtures-betfair`, { params: { date: today } }),
-  useFetch(`${apiUrl}/fixtures-betfair`, { params: { date: tomorrow } }),
-  useFetch(`${apiUrl}/daily-bets`),
-]
-
-const responses = await Promise.all(requests)
-const { data: todayFixtures } = responses[0]
-const { data: tomorrowFixtures } = responses[1]
-const { data: bets } = responses[2]
-
-onMounted(() => {
-  resolveFixtures()
-})
-
-function resolveFixtures() {
-  if (_isEmpty(tomorrowFixtures.value)) {
-    fixturesToUse.value = todayFixtures.value
-    selectedDate.value = today
-
-    isLoading.value = false
-    return
-  }
-
-  fixturesToUse.value = tomorrowFixtures.value
-  selectedDate.value = tomorrow
-  isLoading.value = false
-  return
+if (data.value) {
+  selectedDate.value = data.value.date
+  fixtures.value = data.value.fixtures
+  bets.value = data.value.bets
 }
 
-async function updateFixturesToUse() {
-  let url = `${apiUrl}/fixtures`
-  const transformedDate = selectedDate.value
+isLoading.value = false
 
-  if (betfairFixtures.value) {
-    url = `${apiUrl}/fixtures-betfair`
-  }
-
+async function fetchDaily() {
   isLoading.value = true
-  const data = await $fetch(url, { query: { date: transformedDate } })
+  const result = await $fetch(`${apiUrl}/fixtures/daily`, {
+    query: { date: selectedDate.value, source: source.value },
+  })
+  fixtures.value = result.fixtures
+  bets.value = result.bets
   isLoading.value = false
-  fixturesToUse.value = data
 }
 
 watch(selectedDate, () => {
-  updateFixturesToUse()
+  fetchDaily()
 })
 
-function onSourceChange(betfairToggleStatus) {
-  betfairFixtures.value = betfairToggleStatus
-  updateFixturesToUse()
+function onSourceChange(newSource) {
+  source.value = newSource
+  fetchDaily()
 }
 </script>
 

--- a/app/pages/fixtures.vue
+++ b/app/pages/fixtures.vue
@@ -5,7 +5,6 @@
     <FixturesList
       :fixtures="fixturesToUse"
       :selected-date="selectedDate"
-      :initial-date="initialDate"
       :bets="bets"
       :loading="isLoading"
       @change="onChangeDate"
@@ -21,7 +20,6 @@ const apiUrl = useRuntimeConfig().public.API_URL
 
 const today = DateTime.now().toFormat('yyyy-MM-dd')
 const tomorrow = DateTime.now().plus({ days: 1 }).toFormat('yyyy-MM-dd')
-const initialDate = ref('')
 const selectedDate = ref('')
 const isLoading = ref(true)
 const betfairFixtures = ref(true)
@@ -46,7 +44,6 @@ onMounted(() => {
 function resolveFixtures() {
   if (_isEmpty(tomorrowFixtures.value)) {
     fixturesToUse.value = todayFixtures.value
-    initialDate.value = today
     selectedDate.value = today
 
     isLoading.value = false
@@ -54,7 +51,6 @@ function resolveFixtures() {
   }
 
   fixturesToUse.value = tomorrowFixtures.value
-  initialDate.value = tomorrow
   selectedDate.value = tomorrow
   isLoading.value = false
   return

--- a/app/pages/fixtures.vue
+++ b/app/pages/fixtures.vue
@@ -1,15 +1,12 @@
 <template>
   <div class="flex flex-col gap-5">
-    <PageHeader title="Jogos do dia" />
+    <PageHeader title="Jogos do dia">
+      <template #right>
+        <DatePicker v-model="selectedDate" />
+      </template>
+    </PageHeader>
 
-    <FixturesList
-      :fixtures="fixturesToUse"
-      :selected-date="selectedDate"
-      :bets="bets"
-      :loading="isLoading"
-      @change="onChangeDate"
-      @source-change="onSourceChange"
-    />
+    <FixturesList :fixtures="fixturesToUse" :bets="bets" :loading="isLoading" @source-change="onSourceChange" />
   </div>
 </template>
 
@@ -70,10 +67,9 @@ async function updateFixturesToUse() {
   fixturesToUse.value = data
 }
 
-async function onChangeDate(date) {
-  selectedDate.value = date
+watch(selectedDate, () => {
   updateFixturesToUse()
-}
+})
 
 function onSourceChange(betfairToggleStatus) {
   betfairFixtures.value = betfairToggleStatus

--- a/app/pages/fixtures.vue
+++ b/app/pages/fixtures.vue
@@ -62,7 +62,7 @@ function resolveFixtures() {
 
 async function updateFixturesToUse() {
   let url = `${apiUrl}/fixtures`
-  const transformedDate = selectedDate.value.split('/').reverse().join('-')
+  const transformedDate = selectedDate.value
 
   if (betfairFixtures.value) {
     url = `${apiUrl}/fixtures-betfair`

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -84,40 +84,17 @@
     <UCard v-else id="yesterday-metrics" class="border border-zinc-800 bg-zinc-900">
       <template #header>
         <div class="flex items-center justify-between">
-          <p class="font-semibold text-white">Resultados de {{ formatDate(chosenDate) }}</p>
+          <p class="font-semibold text-white">Resultados de {{ formatDate(chosenDateIso) }}</p>
 
           <div class="flex items-center gap-1">
-            <UButton icon="i-lucide-chevron-left" size="xs" color="secondary" variant="soft" @click="prevDay" />
-
-            <UPopover v-model:open="calendarOpen" :popper="{ placement: 'bottom' }">
-              <UButton
-                :label="formatDate(chosenDate)"
-                size="xs"
-                color="secondary"
-                variant="soft"
-                class="w-28 justify-center"
-              />
-
-              <template #content>
-                <UCalendar v-model="chosenDate" :max-value="maxDate" @update:model-value="calendarOpen = false" />
-              </template>
-            </UPopover>
-
-            <UButton
-              icon="i-lucide-chevron-right"
-              size="xs"
-              color="secondary"
-              variant="soft"
-              :disabled="isAtMaxDate"
-              @click="nextDay"
-            />
+            <DatePicker v-model="chosenDateIso" :max-value="maxDateIso" />
           </div>
         </div>
       </template>
 
       <DataErrorCard
         v-if="!yesterdayData?.results?.length && !dayLoading"
-        :message="`Não foi possível carregar os resultados de ${formatDate(chosenDate)}`"
+        :message="`Não foi possível carregar os resultados de ${formatDate(chosenDateIso)}`"
       />
 
       <template v-else>
@@ -183,7 +160,6 @@
 
 <script setup>
 import { DateTime } from 'luxon'
-import { CalendarDate } from '@internationalized/date'
 
 const runtimeConfig = useRuntimeConfig()
 const apiUrl = runtimeConfig.public.API_URL
@@ -224,48 +200,14 @@ const data = computed(() => {
       : null,
   }
 })
+
 // Date picker
 const timezone = 'America/Sao_Paulo'
 const yesterday = DateTime.now().setZone(timezone).minus({ days: 1 }).toFormat('yyyy-MM-dd')
-const yesterdayParts = yesterday.split('-').map(Number)
-const chosenDate = ref(new CalendarDate(yesterdayParts[0], yesterdayParts[1], yesterdayParts[2]))
-const maxDate = new CalendarDate(
-  ...DateTime.now().setZone(timezone).minus({ days: 1 }).toFormat('yyyy-MM-dd').split('-').map(Number),
-)
+const chosenDateIso = ref(yesterday)
+const maxDateIso = DateTime.now().setZone(timezone).minus({ days: 1 }).toFormat('yyyy-MM-dd')
 const dayLoading = ref(false)
 const yesterdayData = ref({})
-
-function calendarToDateStr(cal) {
-  if (!cal) return ''
-  return `${cal.year}-${String(cal.month).padStart(2, '0')}-${String(cal.day).padStart(2, '0')}`
-}
-
-function formatDate(cal) {
-  if (!cal) return ''
-  return `${String(cal.day).padStart(2, '0')}/${String(cal.month).padStart(2, '0')}/${cal.year}`
-}
-
-function addDays(cal, days) {
-  const d = new Date(cal.year, cal.month - 1, cal.day + days)
-  return new CalendarDate(d.getFullYear(), d.getMonth() + 1, d.getDate())
-}
-
-function isSameDate(a, b) {
-  return a && b && a.year === b.year && a.month === b.month && a.day === b.day
-}
-
-const calendarOpen = ref(false)
-const isAtMaxDate = computed(() => isSameDate(chosenDate.value, maxDate))
-
-function prevDay() {
-  chosenDate.value = addDays(chosenDate.value, -1)
-}
-
-function nextDay() {
-  if (!isAtMaxDate.value) {
-    chosenDate.value = addDays(chosenDate.value, 1)
-  }
-}
 
 const resultsByMonth = computed(() => {
   if (!data.value?.bankrollEvolution?.length) return []
@@ -318,15 +260,16 @@ async function fetchDayResults(date) {
 // Load initial date (use dashboard fallback data or fetch)
 if (data.value?.yesterday?.results?.length) {
   yesterdayData.value = data.value.yesterday
-  const parts = data.value.yesterday.date.split('-').map(Number)
-  chosenDate.value = new CalendarDate(parts[0], parts[1], parts[2])
+  if (data.value.yesterday.date) {
+    chosenDateIso.value = data.value.yesterday.date
+  }
 } else {
   await fetchDayResults(yesterday)
 }
 
 // Refetch when date changes
-watch(chosenDate, (newDate) => {
-  if (newDate) fetchDayResults(calendarToDateStr(newDate))
+watch(chosenDateIso, (newDate) => {
+  if (newDate) fetchDayResults(newDate)
 })
 
 // Store for other pages

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -205,7 +205,7 @@ const data = computed(() => {
 const timezone = 'America/Sao_Paulo'
 const yesterday = DateTime.now().setZone(timezone).minus({ days: 1 }).toFormat('yyyy-MM-dd')
 const chosenDateIso = ref(yesterday)
-const maxDateIso = DateTime.now().setZone(timezone).minus({ days: 1 }).toFormat('yyyy-MM-dd')
+const maxDateIso = yesterday
 const dayLoading = ref(false)
 const yesterdayData = ref({})
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       chartjs-plugin-zoom:
         specifier: ^2.0.1
         version: 2.2.0(chart.js@3.9.1)
+      exceljs:
+        specifier: ^4.4.0
+        version: 4.4.0
       json-server:
         specifier: ^1.0.0-alpha.23
         version: 1.0.0-beta.15
@@ -53,9 +56,6 @@ importers:
       vue-router:
         specifier: ^4.3.0
         version: 4.6.4(vue@3.5.35(typescript@6.0.3))
-      xlsx:
-        specifier: ^0.18.5
-        version: 0.18.5
     devDependencies:
       '@iconify-json/lucide':
         specifier: ^1.2.111
@@ -667,6 +667,12 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@fast-csv/format@4.3.5':
+    resolution: {integrity: sha512-8iRn6QF3I8Ak78lNAa+Gdl5MJJBM5vRHivFtMRUWINdevNo00K7OXxS2PshawLKTejVwieIlPmK5YlLu6w4u8A==}
+
+  '@fast-csv/parse@4.3.6':
+    resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -2118,6 +2124,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/node@14.18.63':
+    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
@@ -2488,10 +2497,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adler-32@1.3.1:
-    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
-    engines: {node: '>=0.8'}
-
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2527,9 +2532,21 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  archiver-utils@2.1.0:
+    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
+    engines: {node: '>= 6'}
+
+  archiver-utils@3.0.4:
+    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
+    engines: {node: '>= 10'}
+
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
     engines: {node: '>= 14'}
+
+  archiver@5.3.2:
+    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
+    engines: {node: '>= 10'}
 
   archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
@@ -2631,6 +2648,13 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  big-integer@1.6.52:
+    resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
+    engines: {node: '>=0.6'}
+
+  binary@0.3.0:
+    resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -2640,8 +2664,17 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  brace-expansion@1.1.15:
+    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
@@ -2659,6 +2692,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
@@ -2666,8 +2702,19 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer-indexof-polyfill@1.0.2:
+    resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
+    engines: {node: '>=0.10'}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buffers@0.1.1:
+    resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
+    engines: {node: '>=0.2.0'}
 
   builtin-modules@5.2.0:
     resolution: {integrity: sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==}
@@ -2705,9 +2752,8 @@ packages:
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
-  cfb@1.2.2:
-    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
-    engines: {node: '>=0.8'}
+  chainsaw@0.1.0:
+    resolution: {integrity: sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -2767,10 +2813,6 @@ packages:
     resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
     engines: {node: '>=0.10.0'}
 
-  codepage@1.15.0:
-    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
-    engines: {node: '>=0.8'}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2805,9 +2847,16 @@ packages:
   compatx@0.2.0:
     resolution: {integrity: sha512-6gLRNt4ygsi5NyMVhceOCFv14CIdDFN7fQjX1U4+47qVE/+kjPoXMK65KWK+dWxmFzMTuKazoQ9sch6pM0p5oA==}
 
+  compress-commons@4.1.2:
+    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
+    engines: {node: '>= 10'}
+
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2841,6 +2890,10 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
     hasBin: true
+
+  crc32-stream@4.0.3:
+    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
+    engines: {node: '>= 10'}
 
   crc32-stream@6.0.0:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
@@ -3010,6 +3063,9 @@ packages:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
+  duplexer2@0.1.4:
+    resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
+
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
@@ -3078,6 +3134,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.22.2:
     resolution: {integrity: sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==}
@@ -3305,12 +3364,20 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  exceljs@4.4.0:
+    resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
+    engines: {node: '>=8.3.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-csv@4.3.6:
+    resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
+    engines: {node: '>=10.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3404,10 +3471,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  frac@1.1.2:
-    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
-    engines: {node: '>=0.8'}
-
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -3429,10 +3492,21 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  fstream@1.0.12:
+    resolution: {integrity: sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==}
+    engines: {node: '>=0.6'}
+    deprecated: This package is no longer supported.
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3486,6 +3560,10 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -3578,6 +3656,9 @@ packages:
   image-meta@0.2.2:
     resolution: {integrity: sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
@@ -3595,6 +3676,10 @@ packages:
   inflection@3.0.2:
     resolution: {integrity: sha512-+Bg3+kg+J6JUWn8J6bzFmOWkTQ6L/NHfDRSYU+EVvuKHDxUDHAXgqixHfVlzuBQaPOTac8hn43aPhMNk6rMe3g==}
     engines: {node: '>=18.0.0'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -3739,6 +3824,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -3768,6 +3856,9 @@ packages:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
     engines: {node: '>=16'}
     hasBin: true
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3855,6 +3946,9 @@ packages:
     engines: {node: '>=22.22.1'}
     hasBin: true
 
+  listenercount@1.0.1:
+    resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
+
   listhen@1.10.0:
     resolution: {integrity: sha512-kfz4C0OrC6IpaVMtYDJtf6PFjurxe9NBBoDAh/o2p587INryFOO4DQ9OetbCdDrWFt1m1CJKvYrzkGsuPHw8nQ==}
     hasBin: true
@@ -3882,8 +3976,45 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.difference@4.5.0:
+    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
+
+  lodash.isfunction@3.0.9:
+    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
+
+  lodash.isnil@4.0.0:
+    resolution: {integrity: sha512-up2Mzq3545mwVnMhTDMdfoG1OurpA/s5t88JmQX809eH3C8491iu2sfKhTfhQtKY78oPNhiaHJUpT/dUDAAtng==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isundefined@3.0.1:
+    resolution: {integrity: sha512-MXB1is3s899/cD8jheYYE2V9qTHwKvt+npCwpD+1Sxm3Q3cECXCiYHjeHWXNwr6Q0SOBPrYUDxendrO6goVTEA==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
+
+  lodash.union@4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -3980,6 +4111,9 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
@@ -3988,6 +4122,9 @@ packages:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3995,6 +4132,10 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -4142,6 +4283,9 @@ packages:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -4206,6 +4350,9 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parse-imports-exports@0.2.4:
     resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
 
@@ -4219,6 +4366,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -4595,6 +4746,10 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4670,6 +4825,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
   rollup-plugin-visualizer@7.0.1:
     resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
     engines: {node: '>=22'}
@@ -4711,6 +4871,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
+
   scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
     engines: {node: ^14.0.0 || >=16.0.0}
@@ -4745,6 +4909,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -4826,10 +4993,6 @@ packages:
     resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
-
-  ssf@0.11.2:
-    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
-    engines: {node: '>=0.8'}
 
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
@@ -4943,6 +5106,10 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
@@ -4979,6 +5146,10 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -4997,6 +5168,9 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  traverse@0.3.9:
+    resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -5189,6 +5363,9 @@ packages:
   unwasm@0.5.3:
     resolution: {integrity: sha512-keBgTSfp3r6+s9ZcSma+0chwxQdmLbB5+dAD9vjtB21UTMYuKAxHXCU1K2CbCtnP09EaWeRvACnXk0EJtUx+hw==}
 
+  unzipper@0.10.14:
+    resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -5203,6 +5380,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vaul-vue@0.4.1:
     resolution: {integrity: sha512-A6jOWOZX5yvyo1qMn7IveoWN91mJI5L3BUKsIwkg6qrTGgHs1Sb1JF/vyLJgnbN1rH4OOOxFbtqL9A46bOyGUQ==}
@@ -5401,17 +5583,9 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
-  wmf@1.0.2:
-    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
-    engines: {node: '>=0.8'}
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
-
-  word@0.3.0:
-    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
-    engines: {node: '>=0.8'}
 
   wrap-ansi@10.0.0:
     resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
@@ -5429,6 +5603,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -5445,14 +5622,12 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
-  xlsx@0.18.5:
-    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
-
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y-protocols@1.0.7:
     resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
@@ -5501,6 +5676,10 @@ packages:
 
   youch@4.1.1:
     resolution: {integrity: sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==}
+
+  zip-stream@4.1.1:
+    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
+    engines: {node: '>= 10'}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -5986,6 +6165,25 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@fast-csv/format@4.3.5':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.isboolean: 3.0.3
+      lodash.isequal: 4.5.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+
+  '@fast-csv/parse@4.3.6':
+    dependencies:
+      '@types/node': 14.18.63
+      lodash.escaperegexp: 4.1.2
+      lodash.groupby: 4.6.0
+      lodash.isfunction: 3.0.9
+      lodash.isnil: 4.0.0
+      lodash.isundefined: 3.0.1
+      lodash.uniq: 4.5.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -7548,6 +7746,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/node@14.18.63': {}
+
   '@types/resolve@1.20.2': {}
 
   '@types/web-bluetooth@0.0.20': {}
@@ -7929,8 +8129,6 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adler-32@1.3.1: {}
-
   agent-base@7.1.4: {}
 
   ajv@6.15.0:
@@ -7961,6 +8159,32 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  archiver-utils@2.1.0:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 2.3.8
+
+  archiver-utils@3.0.4:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
   archiver-utils@5.0.2:
     dependencies:
       glob: 10.5.0
@@ -7970,6 +8194,16 @@ snapshots:
       lodash: 4.18.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
+
+  archiver@5.3.2:
+    dependencies:
+      archiver-utils: 2.1.0
+      async: 3.2.6
+      buffer-crc32: 0.2.13
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
+      tar-stream: 2.2.0
+      zip-stream: 4.1.1
 
   archiver@7.0.1:
     dependencies:
@@ -8059,6 +8293,13 @@ snapshots:
 
   baseline-browser-mapping@2.10.33: {}
 
+  big-integer@1.6.52: {}
+
+  binary@0.3.0:
+    dependencies:
+      buffers: 0.1.1
+      chainsaw: 0.1.0
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -8067,7 +8308,20 @@ snapshots:
 
   birpc@4.0.0: {}
 
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  bluebird@3.4.7: {}
+
   boolbase@1.0.0: {}
+
+  brace-expansion@1.1.15:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@2.1.1:
     dependencies:
@@ -8089,14 +8343,25 @@ snapshots:
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-crc32@0.2.13: {}
+
   buffer-crc32@1.0.0: {}
 
   buffer-from@1.1.2: {}
+
+  buffer-indexof-polyfill@1.0.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buffers@0.1.1: {}
 
   builtin-modules@5.2.0: {}
 
@@ -8139,10 +8404,9 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
-  cfb@1.2.2:
+  chainsaw@0.1.0:
     dependencies:
-      adler-32: 1.3.1
-      crc-32: 1.2.2
+      traverse: 0.3.9
 
   chalk@5.6.2: {}
 
@@ -8195,8 +8459,6 @@ snapshots:
 
   cluster-key-slot@1.1.1: {}
 
-  codepage@1.15.0: {}
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -8219,6 +8481,13 @@ snapshots:
 
   compatx@0.2.0: {}
 
+  compress-commons@4.1.2:
+    dependencies:
+      buffer-crc32: 0.2.13
+      crc32-stream: 4.0.3
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
   compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
@@ -8226,6 +8495,8 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
+
+  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -8248,6 +8519,11 @@ snapshots:
   core-util-is@1.0.3: {}
 
   crc-32@1.2.2: {}
+
+  crc32-stream@4.0.3:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 3.6.2
 
   crc32-stream@6.0.0:
     dependencies:
@@ -8400,6 +8676,10 @@ snapshots:
 
   dotenv@17.4.2: {}
 
+  duplexer2@0.1.4:
+    dependencies:
+      readable-stream: 2.3.8
+
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
@@ -8452,6 +8732,10 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.22.2:
     dependencies:
@@ -8759,6 +9043,18 @@ snapshots:
 
   events@3.3.0: {}
 
+  exceljs@4.4.0:
+    dependencies:
+      archiver: 5.3.2
+      dayjs: 1.11.21
+      fast-csv: 4.3.6
+      jszip: 3.10.1
+      readable-stream: 3.6.2
+      saxes: 5.0.1
+      tmp: 0.2.7
+      unzipper: 0.10.14
+      uuid: 8.3.2
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8772,6 +9068,11 @@ snapshots:
       strip-final-newline: 3.0.0
 
   exsolve@1.0.8: {}
+
+  fast-csv@4.3.6:
+    dependencies:
+      '@fast-csv/format': 4.3.5
+      '@fast-csv/parse': 4.3.6
 
   fast-deep-equal@3.1.3: {}
 
@@ -8895,8 +9196,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  frac@1.1.2: {}
-
   fraction.js@5.3.4: {}
 
   framer-motion@12.40.0:
@@ -8907,8 +9206,19 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  fstream@1.0.12:
+    dependencies:
+      graceful-fs: 4.2.11
+      inherits: 2.0.4
+      mkdirp: 0.5.6
+      rimraf: 2.7.1
 
   function-bind@1.1.2: {}
 
@@ -8954,6 +9264,15 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   global-directory@4.0.1:
     dependencies:
@@ -9039,6 +9358,8 @@ snapshots:
 
   image-meta@0.2.2: {}
 
+  immediate@3.0.6: {}
+
   import-meta-resolve@4.2.0: {}
 
   impound@1.1.5:
@@ -9054,6 +9375,11 @@ snapshots:
   indent-string@5.0.0: {}
 
   inflection@3.0.2: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
 
   inherits@2.0.4: {}
 
@@ -9181,6 +9507,13 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -9208,6 +9541,10 @@ snapshots:
   lib0@0.2.117:
     dependencies:
       isomorphic.js: 0.2.5
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -9271,6 +9608,8 @@ snapshots:
     optionalDependencies:
       yaml: 2.9.0
 
+  listenercount@1.0.1: {}
+
   listhen@1.10.0(srvx@0.11.16):
     dependencies:
       '@parcel/watcher': 2.5.6
@@ -9320,7 +9659,31 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.difference@4.5.0: {}
+
+  lodash.escaperegexp@4.1.2: {}
+
+  lodash.flatten@4.4.0: {}
+
+  lodash.groupby@4.6.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
+
+  lodash.isfunction@3.0.9: {}
+
+  lodash.isnil@4.0.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isundefined@3.0.1: {}
+
   lodash.memoize@4.1.2: {}
+
+  lodash.union@4.6.0: {}
 
   lodash.uniq@4.5.0: {}
 
@@ -9412,6 +9775,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.6
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.15
+
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.1.1
@@ -9420,11 +9787,17 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.1
 
+  minimist@1.2.8: {}
+
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.3
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
 
   mlly@1.8.2:
     dependencies:
@@ -9762,6 +10135,10 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -9887,6 +10264,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@1.0.11: {}
+
   parse-imports-exports@0.2.4:
     dependencies:
       parse-statements: 1.0.11
@@ -9896,6 +10275,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -10234,6 +10615,12 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readable-stream@4.7.0:
     dependencies:
       abort-controller: 3.0.0
@@ -10311,6 +10698,10 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
+
   rollup-plugin-visualizer@7.0.1(rollup@4.61.1):
     dependencies:
       open: 11.0.0
@@ -10367,6 +10758,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@5.0.1:
+    dependencies:
+      xmlchars: 2.2.0
+
   scslre@0.3.0:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -10411,6 +10806,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -10483,10 +10880,6 @@ snapshots:
   spdx-license-ids@3.0.23: {}
 
   srvx@0.11.16: {}
-
-  ssf@0.11.2:
-    dependencies:
-      frac: 1.1.2
 
   stable-hash-x@0.2.0: {}
 
@@ -10592,6 +10985,14 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.2.0:
     dependencies:
       b4a: 1.8.1
@@ -10644,6 +11045,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tmp@0.2.7: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -10658,6 +11061,8 @@ snapshots:
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
+
+  traverse@0.3.9: {}
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -10865,6 +11270,19 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.1
 
+  unzipper@0.10.14:
+    dependencies:
+      big-integer: 1.6.52
+      binary: 0.3.0
+      bluebird: 3.4.7
+      buffer-indexof-polyfill: 1.0.2
+      duplexer2: 0.1.4
+      fstream: 1.0.12
+      graceful-fs: 4.2.11
+      listenercount: 1.0.1
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -10878,6 +11296,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@8.3.2: {}
 
   vaul-vue@0.4.1(reka-ui@2.9.9(vue@3.5.35(typescript@6.0.3)))(vue@3.5.35(typescript@6.0.3)):
     dependencies:
@@ -11066,11 +11486,7 @@ snapshots:
     dependencies:
       isexe: 4.0.0
 
-  wmf@1.0.2: {}
-
   word-wrap@1.2.5: {}
-
-  word@0.3.0: {}
 
   wrap-ansi@10.0.0:
     dependencies:
@@ -11096,6 +11512,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
   ws@8.21.0: {}
 
   wsl-utils@0.3.1:
@@ -11103,17 +11521,9 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  xlsx@0.18.5:
-    dependencies:
-      adler-32: 1.3.1
-      cfb: 1.2.2
-      codepage: 1.15.0
-      crc-32: 1.2.2
-      ssf: 0.11.2
-      wmf: 1.0.2
-      word: 0.3.0
-
   xml-name-validator@4.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y-protocols@1.0.7(yjs@13.6.31):
     dependencies:
@@ -11159,6 +11569,12 @@ snapshots:
       '@speed-highlight/core': 1.2.15
       cookie-es: 3.1.1
       youch-core: 0.3.3
+
+  zip-stream@4.1.1:
+    dependencies:
+      archiver-utils: 3.0.4
+      compress-commons: 4.1.2
+      readable-stream: 3.6.2
 
   zip-stream@6.0.1:
     dependencies:


### PR DESCRIPTION
# Refactor `/fixtures` — Design System Zinc + API Otimizada

## Resumo

Refactor completo da página `/fixtures`: design system zinc, 2 componentes compartilhados extraídos, drawer mobile, shimmer hover, e otimização de dados (12.6MB → 11.8KB).

## O que mudou

### Design System
- Migração completa da paleta slate/gray → **zinc** em todos os arquivos do fixtures
- **DatePicker** extraído como componente compartilhado (reutilizado no dashboard)
- **SegmentedControl** extraído como componente compartilhado (substitui UTabs)
- Badges H/D/A: apenas o **favorito** fica teal (sem vermelho no underdog)
- **Shimmer hover** nos fixture cards (mesmo efeito do rankingModels)
- **Rounded-2xl** em todos os cards, skeletons e stat rows
- **FixtureDetailsCard** reestruturado: header + 3 stat rows (Match Odds, O/U 2.5, BTTS) + lista de modelos

### Layout
- DatePicker movido para o **lado direito do PageHeader**
- SegmentedControl e contador de jogos na mesma linha (justify-between)
- Container de controles: `sm:w-1/2` alinhado com os cards
- Abaixo de 1024px: layout full-width (cards + controles)

### Mobile (abaixo de 1024px)
- Painel de detalhes **não aparece** — tudo via **UDrawer** (bottom sheet)
- Skeleton responsivo: coluna única no mobile, duas colunas no desktop
- Cards e controles full-width

### API (backend + frontend)
- **Novo endpoint:** `GET /fixtures/daily?date=YYYY-MM-DD&source=exchange|bookie`
- Backend resolve automaticamente a data (tenta amanhã, se vazio usa hoje)
- Combina fixtures + bets em **1 request** (antes eram 3)
- Bets filtrados **por data** (antes retornava 64.723 bets de todas as datas)
- **Resultado real:** 12.6MB → 11.8KB (-99.9%), ~6.8s → 1.03s (6.6x mais rápido)

## Commits

```
6cdf906 refactor: use single /fixtures/daily endpoint
6f99bd3 fix: drawer with #content slot, responsive skeleton, and full-width cards below 1024px
9d3cd2f style: apply rounded-2xl to all cards, skeletons, and stat rows
f4ce396 fix: constrain controls row to 50% width on desktop
e0c1369 style: favorite-only teal badges and details card polish
98c84f2 style(fixtureCard): remove responsive font size on date subtext
655515f fix: align SegmentedControl right of counter in controls row
99c74ff fix: move jogos counter back below controls row
859d5f2 fix: move DatePicker to header and add shimmer hover to fixture cards
45c649c refactor(dashboard): dedupe maxDateIso with yesterday constant
9248bd0 refactor: use shared DatePicker in dashboard
22f47ea refactor(fixtures): drop dead initialDate prop
b623db5 refactor: migrate fixtures page to zinc design system
ad83283 fix(SegmentedControl): align typography and modelValue required with spec
a880e0a feat: extract DatePicker and SegmentedControl shared components
```

## Arquivos alterados

### Novos
- `app/components/DatePicker.vue` — componente compartilhado de data (v-model ISO string)
- `app/components/SegmentedControl.vue` — componente compartilhado de segmented control

### Modificados
- `app/pages/fixtures.vue` — refatorado para usar `/fixtures/daily` (1 request)
- `app/pages/index.vue` — consome `<DatePicker>` compartilhado
- `app/components/fixturesList.vue` — zinc, drawer, layout responsivo
- `app/components/fixtureCard.vue` — zinc, shimmer, badges favorito-only
- `app/components/fixtureDetailsCard.vue` — reestruturado com stat rows
- `app/components/fixturesListSkeleton.vue` — responsivo (coluna única mobile)

### Não alterados
- `app/components/fixturesListSkeleton.vue` (cores)
- `app/components/pageHeader.vue`
- `app/app.config.ts`

## Como testar

1. Abrir `/fixtures` — cards com paleta zinc, shimmer no hover
2. Clicar num card no desktop → painel de detalhes à direita
3. Clicar num card no mobile (< 1024px) → drawer abre de baixo
4. Trocar Exchange/Bookie → lista atualiza
5. Mudar data via DatePicker → lista atualiza
6. Abrir `/` → dashboard funciona normalmente com DatePicker compartilhado
7. Verificar Network tab: 1 request para `/fixtures/daily` (não 3)
