### PR TITLE
feat: add Academy glossary page (/academy)

### DIFF
--- a/app/components/AGENTS.md
+++ b/app/components/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-All 23 Vue components for the DataPlay Bets dashboard. Flat directory structure — no subdirectories.
+All 24 Vue components for the DataPlay Bets dashboard. Flat directory structure — no subdirectories.
 
 ## Ownership
 
@@ -22,6 +22,7 @@ All 23 Vue components for the DataPlay Bets dashboard. Flat directory structure 
 
 | Component | Purpose | Key Notes |
 |-----------|---------|-----------|
+| `academyTermCard.vue` | Card expansível de termo do glossário pra `/academy` | Barra lateral colorida por categoria (teal/violet/amber), click alterna estado expandido, mostra short/long/example |
 | `bankrollEvolution.vue` | Line chart: bankroll growth over months | Uses `LineChart` from vue-chart-3, options from `useBankrollChartOptions` |
 | `betsTableCard.vue` | Paginated table of model bets | UTable + UPagination, page emit |
 | `blockMetricsCard.vue` | Statistical metrics: mean P/L, std dev, confidence interval | |

--- a/app/components/academyTermCard.vue
+++ b/app/components/academyTermCard.vue
@@ -7,9 +7,9 @@
     <div class="mb-2 flex items-start justify-between gap-2">
       <h3 class="text-base font-semibold text-white">{{ term.name }}</h3>
 
-      <UBadge :color="badgeColor" variant="subtle" size="xs">
+      <span class="text-xs font-semibold" :class="textColorClass">
         {{ term.category }}
-      </UBadge>
+      </span>
     </div>
 
     <p class="text-sm leading-relaxed text-zinc-400">{{ term.short }}</p>
@@ -51,12 +51,12 @@ const borderColorClass = computed(() => {
   return map[props.term.category] || 'border-l-zinc-500'
 })
 
-const badgeColor = computed(() => {
+const textColorClass = computed(() => {
   const map = {
-    Conceito: 'teal',
-    Estratégia: 'violet',
-    Modelo: 'amber',
+    Conceito: 'text-teal-500',
+    Estratégia: 'text-violet-500',
+    Modelo: 'text-amber-500',
   }
-  return map[props.term.category] || 'neutral'
+  return map[props.term.category] || 'text-zinc-500'
 })
 </script>

--- a/app/components/academyTermCard.vue
+++ b/app/components/academyTermCard.vue
@@ -14,8 +14,8 @@
 
     <p class="line-clamp-2 text-sm leading-relaxed text-zinc-400">{{ term.short }}</p>
 
-    <template v-if="expanded">
-      <div class="mt-4 space-y-3">
+    <Transition name="expand">
+      <div v-if="expanded" class="mt-4 space-y-3 overflow-hidden">
         <div>
           <p class="mb-1 text-xs font-medium tracking-wide text-zinc-500 uppercase">Detalhe</p>
 
@@ -28,7 +28,7 @@
           <p class="text-sm leading-relaxed text-zinc-300">{{ term.example }}</p>
         </div>
       </div>
-    </template>
+    </Transition>
   </div>
 </template>
 
@@ -60,3 +60,23 @@ const textColorClass = computed(() => {
   return map[props.term.category] || 'text-zinc-500'
 })
 </script>
+
+<style scoped>
+.expand-enter-active,
+.expand-leave-active {
+  transition:
+    max-height 0.3s ease,
+    opacity 0.3s ease;
+  overflow: hidden;
+}
+.expand-enter-from,
+.expand-leave-to {
+  max-height: 0;
+  opacity: 0;
+}
+.expand-enter-to,
+.expand-leave-from {
+  max-height: 500px;
+  opacity: 1;
+}
+</style>

--- a/app/components/academyTermCard.vue
+++ b/app/components/academyTermCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="cursor-pointer rounded-2xl border border-l-[3px] border-zinc-800 bg-zinc-900 p-4 transition-colors hover:bg-zinc-800/60"
+    class="min-h-28 cursor-pointer rounded-2xl border border-l-[3px] border-zinc-800 bg-zinc-900 p-4 transition-colors hover:bg-zinc-800/60"
     :class="borderColorClass"
     @click="expanded = !expanded"
   >

--- a/app/components/academyTermCard.vue
+++ b/app/components/academyTermCard.vue
@@ -12,7 +12,7 @@
       </span>
     </div>
 
-    <p class="text-sm leading-relaxed text-zinc-400">{{ term.short }}</p>
+    <p class="line-clamp-2 text-sm leading-relaxed text-zinc-400">{{ term.short }}</p>
 
     <template v-if="expanded">
       <div class="mt-4 space-y-3">

--- a/app/components/academyTermCard.vue
+++ b/app/components/academyTermCard.vue
@@ -1,0 +1,62 @@
+<template>
+  <div
+    class="cursor-pointer rounded-2xl border border-l-[3px] border-zinc-800 bg-zinc-900 p-4 transition-colors hover:bg-zinc-800/60"
+    :class="borderColorClass"
+    @click="expanded = !expanded"
+  >
+    <div class="mb-2 flex items-start justify-between gap-2">
+      <h3 class="text-base font-semibold text-white">{{ term.name }}</h3>
+
+      <UBadge :color="badgeColor" variant="subtle" size="xs">
+        {{ term.category }}
+      </UBadge>
+    </div>
+
+    <p class="text-sm leading-relaxed text-zinc-400">{{ term.short }}</p>
+
+    <template v-if="expanded">
+      <div class="mt-4 space-y-3">
+        <div>
+          <p class="mb-1 text-xs font-medium tracking-wide text-zinc-500 uppercase">Detalhe</p>
+
+          <p class="text-sm leading-relaxed whitespace-pre-line text-zinc-300">{{ term.long }}</p>
+        </div>
+
+        <div>
+          <p class="mb-1 text-xs font-medium tracking-wide text-zinc-500 uppercase">Exemplo</p>
+
+          <p class="text-sm leading-relaxed text-zinc-300">{{ term.example }}</p>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  term: {
+    type: Object,
+    required: true,
+  },
+})
+
+const expanded = ref(false)
+
+const borderColorClass = computed(() => {
+  const map = {
+    Conceito: 'border-l-teal-500',
+    Estratégia: 'border-l-violet-500',
+    Modelo: 'border-l-amber-500',
+  }
+  return map[props.term.category] || 'border-l-zinc-500'
+})
+
+const badgeColor = computed(() => {
+  const map = {
+    Conceito: 'teal',
+    Estratégia: 'violet',
+    Modelo: 'amber',
+  }
+  return map[props.term.category] || 'neutral'
+})
+</script>

--- a/app/composables/useAcademiaGlossario.js
+++ b/app/composables/useAcademiaGlossario.js
@@ -1,0 +1,94 @@
+import glossarioRaw from '~/data/academia/glossario.json'
+
+const CATEGORIES = ['Conceito', 'Estratégia', 'Modelo']
+
+const REQUIRED_FIELDS = ['name', 'category', 'short', 'long', 'example']
+
+const FIELD_LIMITS = {
+  name: { min: 1, max: 40 },
+  short: { min: 10, max: 200 },
+  long: { min: 30, max: 1500 },
+  example: { min: 10, max: 500 },
+}
+
+function validateTerm(term) {
+  const errors = []
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!(field in term) || term[field] === undefined || term[field] === null) {
+      errors.push(`campo obrigatório ausente: ${field}`)
+    }
+  }
+
+  if (errors.length) return errors
+
+  if (typeof term.name !== 'string') errors.push('name deve ser string')
+  if (typeof term.category !== 'string' || !CATEGORIES.includes(term.category)) {
+    errors.push(`category inválida: ${term.category} (esperado: ${CATEGORIES.join(', ')})`)
+  }
+
+  for (const [field, { min, max }] of Object.entries(FIELD_LIMITS)) {
+    const val = term[field]
+    if (typeof val === 'string') {
+      if (val.length < min) errors.push(`${field} muito curto (${val.length} < ${min})`)
+      if (val.length > max) errors.push(`${field} muito longo (${val.length} > ${max})`)
+    }
+  }
+
+  return errors
+}
+
+function loadAndValidate() {
+  let raw
+  try {
+    raw = typeof glossarioRaw === 'string' ? JSON.parse(glossarioRaw) : glossarioRaw
+  } catch (e) {
+    console.error(`Academia: glossario.json inválido: ${e.message}`)
+    return []
+  }
+
+  if (!Array.isArray(raw)) {
+    console.error('Academia: glossario.json deve ser um array')
+    return []
+  }
+
+  const validTerms = []
+  const seenNames = new Set()
+
+  for (let i = 0; i < raw.length; i++) {
+    const term = raw[i]
+    const errors = validateTerm(term)
+
+    if (errors.length) {
+      const label = term?.name || `índice ${i}`
+      console.error(`Academia: termo '${label}' inválido: ${errors.join('; ')}`)
+      continue
+    }
+
+    if (seenNames.has(term.name)) {
+      console.error(`Academia: nome duplicado '${term.name}'`)
+      continue
+    }
+
+    seenNames.add(term.name)
+    validTerms.push(term)
+  }
+
+  return validTerms
+}
+
+const terms = loadAndValidate()
+
+const byCategory = _groupBy(terms, 'category')
+
+function search(query) {
+  if (!query || !query.trim()) return terms
+  const q = query.toLowerCase().trim()
+  return terms.filter(
+    (t) => t.name.toLowerCase().includes(q) || t.short.toLowerCase().includes(q) || t.long.toLowerCase().includes(q),
+  )
+}
+
+export function useAcademiaGlossario() {
+  return { terms, byCategory, search }
+}

--- a/app/data/AGENTS.md
+++ b/app/data/AGENTS.md
@@ -1,0 +1,27 @@
+# app/data/ — Static Data Files
+
+## Purpose
+
+Static JSON data consumed by composables at build time (Vite static import). No API calls for this data.
+
+## Ownership
+
+- `academia/glossario.json` — 11 glossary terms for the `/academy` page
+- `academia/glossario.schema.json` — JSON Schema draft-07 for term validation
+
+## Local Contracts
+
+- JSON files are imported directly by composables (no fetch, no API)
+- Schema validates at runtime in the composable, not at build time
+- Adding a new term: add to `glossario.json`, ensure it passes schema (name unique, required fields, maxLength respected)
+- Categories: `Conceito`, `Estratégia`, `Modelo` (enum in schema)
+
+## Work Guidance
+
+- Edit `glossario.json` to add/remove terms — the composable validates on load
+- Schema changes require updating the composable validator to match
+
+## Verification
+
+- Add a term with a missing field → `console.error` + term skipped in UI
+- Add a term with a duplicate name → `console.error` + second term skipped

--- a/app/data/academia/glossario.json
+++ b/app/data/academia/glossario.json
@@ -1,0 +1,79 @@
+[
+  {
+    "name": "modelo",
+    "category": "Conceito",
+    "short": "Um \"especialista digital\" que analisou milhares de jogos antigos pra dizer o que acha que vai acontecer nos jogos de hoje.",
+    "long": "Ele olha o histórico dos times, aprendeu padrões (time que tá em boa fase, time que costuma levar gol fora de casa, etc.) e usa isso pra dar uma opinião sobre o jogo. Não é chute nem bola de cristal — é estatística. A plataforma roda vários modelos ao mesmo tempo, cada um focado num tipo de situação. Quando a opinião do modelo bate com uma odd boa da casa, nasce uma aposta.",
+    "example": "\"O modelo achou que esse jogo tem 65% de chance de ter gol no 1º tempo\" — significa que o programa, olhando os times, considera isso provável com base no histórico deles."
+  },
+  {
+    "name": "odd",
+    "category": "Conceito",
+    "short": "O número que a casa de aposta dá pra um resultado. É o \"multiplicador\" do que você ganha.",
+    "long": "A odd diz quanto você recebe se acertar a aposta. Exemplo: odd de 2.0 quer dizer que pra cada R$1 que você colocar, recebe R$2 de volta (R$1 de lucro + R$1 da sua stake). Quanto maior a odd, mais arriscado a casa considera o resultado — e maior o lucro se você acertar. A plataforma usa odd decimal, que é a mais comum no Brasil.",
+    "example": "Odd 1.50 pro favorito = vitória esperada, lucro pequeno. Odd 5.00 pro azarão = improvável, mas se der, lucro bem maior."
+  },
+  {
+    "name": "valor esperado",
+    "category": "Conceito",
+    "short": "O que diz se uma aposta é boa ou ruim a longo prazo.",
+    "long": "Pense assim: se você fizesse a mesma aposta mil vezes, ganharia dinheiro ou perderia? Se ganhar, ela tem valor. Se perder, não tem. A plataforma calcula isso pra cada jogo: cruza o que o modelo acha que vai acontecer com o quanto a casa tá pagando. Quando a casa paga mais do que deveria, nasce uma aposta de valor.",
+    "example": "O modelo diz que o time tem 60% de chance de ganhar. A casa paga odd 2.20. A aposta tem valor, porque a casa tá pagando como se a chance fosse menor. Se a casa pagasse odd 1.50, não teria valor — a chance real é maior do que o pagamento sugere."
+  },
+  {
+    "name": "stake",
+    "category": "Conceito",
+    "short": "Quanto dinheiro você coloca numa aposta. É o que você arrisca.",
+    "long": "Cada aposta tem um valor em reais — R$5, R$20, R$100. Esse valor é o stake. Se você perder a aposta, perde o stake. Se ganhar, recebe de volta o stake + o lucro, que é calculado pela odd. A plataforma usa uma stake padrão por aposta pra manter o risco controlado, mas o tamanho exato pode variar de acordo com a banca e o valor esperado da aposta.\nObs.: em apostas lay, a mecânica é diferente — vale ver o card de lay.",
+    "example": "Stake de R$20 numa odd 2.50. Ganhou: recebe R$50 no total (R$30 de lucro + R$20 da stake de volta). Perdeu: perde os R$20."
+  },
+  {
+    "name": "banca",
+    "category": "Conceito",
+    "short": "O total de dinheiro que você tem separado pra apostar. É o seu \"caixa\".",
+    "long": "É o caixa da atividade. Tudo o que você tem disponível pra colocar em apostas. A regra de ouro é nunca apostar mais do que 1–5% da banca numa aposta só — isso evita que uma sequência ruim te quebre. A plataforma ajusta a stake de cada aposta automaticamente pra manter esse percentual, então mesmo perdendo várias seguidas, a stake vai diminuindo junto com a banca.",
+    "example": "Banca de R$1.000 e stake de 2% = R$20 por jogo. Perde 5 seguidos: banca cai pra R$900, stake cai pra R$18. Ganha uma odd 2.50 na próxima: banca sobe pra R$945, stake sobe pra R$19."
+  },
+  {
+    "name": "ROI",
+    "category": "Conceito",
+    "short": "Quanto você ganhou (ou perdeu) em porcentagem do que apostou. É a régua principal pra saber se tá dando certo.",
+    "long": "ROI = lucro total ÷ total apostado, em porcentagem. Apostou R$1.000 no mês e lucrou R$80? ROI de 8%. Perdeu R$50? ROI de -5%. A plataforma calcula ROI por modelo, por período, por liga — assim você vê o que tá funcionando e o que não tá. ROI positivo no longo prazo é o que separa apostador comum de quem investe em aposta.",
+    "example": "Mês com 50 apostas, stake total R$1.000, lucro R$120 → ROI de +12%. Outro mês com 50 apostas, stake R$1.000, prejuízo R$80 → ROI de -8%."
+  },
+  {
+    "name": "aposta",
+    "category": "Conceito",
+    "short": "Uma recomendação de aposta gerada por um modelo. É o que aparece na lista do dia pra você seguir.",
+    "long": "É a \"unidade de ação\" da plataforma. Cada aposta é um conjunto de informações: o jogo, o tipo (back ou lay), a odd, e o modelo que recomendou. Você olha a lista do dia, vê o que os modelos acham que tem valor, e decide se quer seguir — aí você mesma monta a stake e coloca na casa ou exchange.",
+    "example": "\"Hoje tem 12 apostas. O modelo LTD gerou 3, o lay_away gerou 2, o lay_0x0 gerou 4. Cada uma mostra: jogo, tipo (back/lay), odd e qual modelo sugeriu.\""
+  },
+  {
+    "name": "win rate",
+    "category": "Conceito",
+    "short": "A porcentagem de apostas que você acertou. Na plataforma aparece como \"WR\".",
+    "long": "É a sua taxa de acerto. De cada 10 apostas, em quantas você ganhou? Se acertou 6, seu WR é 60%. Cuidado: WR alto não quer dizer lucro alto. Você pode acertar 80% das apostas com odds baixíssimas e ainda assim perder dinheiro. O que importa mesmo é o ROI — o WR é só um pedaço da história.",
+    "example": "100 apostas no mês, 55 ganhas → WR 55%. Outro mês: 80 apostas, 50 ganhas → WR 62,5%. Mas se as odds eram baixas no segundo mês, o ROI pode ter sido pior mesmo com mais acertos."
+  },
+  {
+    "name": "back",
+    "category": "Estratégia",
+    "short": "Aposte a favor de um resultado acontecer. É o tipo mais comum de aposta.",
+    "long": "\"Back\" é torcer pelo resultado. Você aposta que o time A vai ganhar, que vai ter mais de 2.5 gols, que o visitante vai marcar primeiro. É o jeito tradicional — funciona em qualquer casa, presencial ou online. Você paga a stake, e se acertar, recebe odd × stake. A maioria das apostas que a plataforma recomenda é back.",
+    "example": "\"Back no mandante a odd 1.80\" = você tá apostando que o time da casa vai ganhar. Se ganhar, você lucra. Se perder ou empatar, perde a stake."
+  },
+  {
+    "name": "lay",
+    "category": "Estratégia",
+    "short": "Aposte CONTRA um resultado acontecer. Você tá dizendo \"isso NÃO vai rolar\".",
+    "long": "\"Lay\" é o oposto de back. Em vez de torcer pro time ganhar, você aposta que ele NÃO vai ganhar. Funciona em exchanges (como Betfair) — não em casas tradicionais. Você tá \"vendendo\" a aposta pra outro apostador. Os modelos da plataforma usam muito lay pra dizer \"esse favoritismo é furada — o time da casa não vai ganhar\".\nComo funciona a stake: numa aposta lay, o valor que você coloca é a \"responsabilidade\" — o máximo que você paga se perder. O lucro, se ganhar, é a \"stake do backer\" (o que o outro apostador teria ganhado). É o espelho do back.",
+    "example": "\"Lay no mandante a odd 1.80, responsabilidade R$80\" = você arrisca R$80 contra o time da casa. Se ele perder ou empatar, você ganha R$100 (a stake do backer). Se ele ganhar, você perde os R$80."
+  },
+  {
+    "name": "LTD",
+    "category": "Modelo",
+    "short": "Lay The Draw. Um modelo que procura jogos onde vale a pena apostar contra o empate.",
+    "long": "LTD é um dos modelos da plataforma. A lógica: em jogos onde o time da casa é favorito claro, a odd do empate geralmente sobe (a casa precifica alto o empate). O LTD procura os casos em que essa odd do empate tá \"barata demais\" — ou seja, a chance real do empate é menor do que a odd sugere. Aí ele recomenda fazer lay no empate. Você lucra se o jogo terminar com vitória de qualquer um dos dois times.",
+    "example": "Jogo Real Madrid x Betis, odd do empate 4.20. O LTD diz: \"acho que o empate tem só 18% de chance, mas a casa tá pagando como se fosse 24%\". Aí ele recomenda lay no empate a 4.20. Jogo termina 2x0 → você ganha."
+  }
+]

--- a/app/data/academia/glossario.schema.json
+++ b/app/data/academia/glossario.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AcademyTerm",
+  "type": "object",
+  "required": ["name", "category", "short", "long", "example"],
+  "additionalProperties": false,
+  "properties": {
+    "name":     { "type": "string", "minLength": 1, "maxLength": 40 },
+    "category": { "enum": ["Conceito", "Estratégia", "Modelo"] },
+    "short":    { "type": "string", "minLength": 10, "maxLength": 200 },
+    "long":     { "type": "string", "minLength": 30, "maxLength": 1500 },
+    "example":  { "type": "string", "minLength": 10, "maxLength": 500 }
+  }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -26,6 +26,11 @@ const navItems = [
       icon: 'i-lucide-bar-chart-3',
       to: '/performance',
     },
+    {
+      label: 'Academia',
+      icon: 'i-lucide-graduation-cap',
+      to: '/academy',
+    },
   ],
 ]
 </script>

--- a/app/pages/AGENTS.md
+++ b/app/pages/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Nuxt file-based routing pages. 4 routes total.
+Nuxt file-based routing pages. 5 routes total.
 
 ## Ownership
 
@@ -24,6 +24,7 @@ Nuxt file-based routing pages. 4 routes total.
 | `fixtures.vue` | `/fixtures` | Daily games with date picker + source toggle (default: Bookie) |
 | `daily-bets.vue` | `/daily-bets` | Effective-date bet list (cards) with model filter. Uses `useDailyBets` + `useDailyBetsDates`. The model `USelectMenu` (searchable) options are the unique `Modelo` values from the current bet list. On first load, `date` is synced from the API's resolved effective date (tomorrow, fallback today); `DatePicker` lets the user navigate. `<DailyBetCard>` per bet. |
 | `performance/[[model]].vue` | `/performance` or `/performance/:model` | Model performance: chart, metrics, blocks, bets, results |
+| `academy.vue` | `/academy` | Glossário de termos da plataforma: busca ao vivo, agrupado por categoria, cards expansíveis. Usa `useAcademiaGlossario` + `glossario.json`. |
 
 ## Work Guidance
 

--- a/app/pages/academy.vue
+++ b/app/pages/academy.vue
@@ -13,7 +13,7 @@
             {{ cat }} ({{ filteredByCategory[cat]?.length || 0 }})
           </h2>
 
-          <div class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+          <div class="grid grid-cols-1 items-start gap-3 md:grid-cols-2 lg:grid-cols-3">
             <AcademyTermCard v-for="term in filteredByCategory[cat]" :key="term.name" :term="term" />
           </div>
         </div>

--- a/app/pages/academy.vue
+++ b/app/pages/academy.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="flex flex-col gap-5">
+    <PageHeader title="Academia" description="Aprenda os termos da plataforma" />
+
+    <UInput v-model="searchQuery" icon="i-lucide-search" placeholder="Buscar termo..." size="lg" class="w-full" />
+
+    <DataErrorCard v-if="!terms.length" icon="i-lucide-info" message="Glossário vazio por enquanto" />
+
+    <template v-else>
+      <template v-for="cat in visibleCategories" :key="cat">
+        <div>
+          <h2 class="mb-3 text-sm font-semibold tracking-wide text-zinc-500 uppercase">
+            {{ cat }} ({{ filteredByCategory[cat]?.length || 0 }})
+          </h2>
+
+          <div class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+            <AcademyTermCard v-for="term in filteredByCategory[cat]" :key="term.name" :term="term" />
+          </div>
+        </div>
+      </template>
+
+      <p v-if="searchQuery && visibleCategories.length === 0" class="text-sm text-zinc-500">
+        Nenhum termo encontrado pra "{{ searchQuery }}"
+      </p>
+    </template>
+  </div>
+</template>
+
+<script setup>
+const { terms, search } = useAcademiaGlossario()
+
+const searchQuery = ref('')
+
+const CATEGORY_ORDER = ['Conceito', 'Estratégia', 'Modelo']
+
+const filtered = computed(() => search(searchQuery.value))
+
+const filteredByCategory = computed(() => _groupBy(filtered.value, 'category'))
+
+const visibleCategories = computed(() => CATEGORY_ORDER.filter((cat) => filteredByCategory.value[cat]?.length > 0))
+</script>

--- a/tests/app/components/academyTermCard.spec.ts
+++ b/tests/app/components/academyTermCard.spec.ts
@@ -1,0 +1,73 @@
+// @vitest-environment nuxt
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import AcademyTermCard from '~/components/academyTermCard.vue'
+
+const baseTerm = {
+  name: 'odd',
+  category: 'Conceito',
+  short: 'O número que a casa de aposta dá pra um resultado.',
+  long: 'A odd diz quanto você recebe se acertar a aposta. Exemplo: odd de 2.0 quer dizer que pra cada R$1 que você colocar, recebe R$2 de volta.',
+  example: 'Odd 1.50 pro favorito = vitória esperada, lucro pequeno.',
+}
+
+describe('AcademyTermCard', () => {
+  it('renders name and short on the collapsed face', async () => {
+    const wrapper = await mountSuspended(AcademyTermCard, { props: { term: baseTerm } })
+    const text = wrapper.text()
+    expect(text).toContain('odd')
+    expect(text).toContain(baseTerm.short)
+  })
+
+  it('hides long and example when collapsed', async () => {
+    const wrapper = await mountSuspended(AcademyTermCard, { props: { term: baseTerm } })
+    const text = wrapper.text()
+    expect(text).not.toContain(baseTerm.long)
+    expect(text).not.toContain(baseTerm.example)
+  })
+
+  it('expands on click to show long and example', async () => {
+    const wrapper = await mountSuspended(AcademyTermCard, { props: { term: baseTerm } })
+    await wrapper.trigger('click')
+    await wrapper.vm.$nextTick()
+    const text = wrapper.text()
+    expect(text).toContain(baseTerm.long)
+    expect(text).toContain(baseTerm.example)
+  })
+
+  it('collapses on second click', async () => {
+    const wrapper = await mountSuspended(AcademyTermCard, { props: { term: baseTerm } })
+    await wrapper.trigger('click')
+    await wrapper.vm.$nextTick()
+    await wrapper.trigger('click')
+    await wrapper.vm.$nextTick()
+    const text = wrapper.text()
+    expect(text).not.toContain(baseTerm.long)
+    expect(text).not.toContain(baseTerm.example)
+  })
+
+  it('renders teal-500 left border for Conceito category', async () => {
+    const wrapper = await mountSuspended(AcademyTermCard, { props: { term: baseTerm } })
+    const el = wrapper.element as HTMLElement
+    expect(el.className).toContain('border-l-teal-500')
+  })
+
+  it('renders violet-500 left border for Estratégia category', async () => {
+    const term = { ...baseTerm, name: 'back', category: 'Estratégia' }
+    const wrapper = await mountSuspended(AcademyTermCard, { props: { term } })
+    const el = wrapper.element as HTMLElement
+    expect(el.className).toContain('border-l-violet-500')
+  })
+
+  it('renders amber-500 left border for Modelo category', async () => {
+    const term = { ...baseTerm, name: 'LTD', category: 'Modelo' }
+    const wrapper = await mountSuspended(AcademyTermCard, { props: { term } })
+    const el = wrapper.element as HTMLElement
+    expect(el.className).toContain('border-l-amber-500')
+  })
+
+  it('renders the category badge text', async () => {
+    const wrapper = await mountSuspended(AcademyTermCard, { props: { term: baseTerm } })
+    expect(wrapper.text()).toContain('Conceito')
+  })
+})


### PR DESCRIPTION
## Summary

Página `/academy` com glossário estático de 11 termos da plataforma, agrupados por categoria, com busca ao vivo e cards expansíveis.

## What was built

- **Data layer** (`app/data/academia/`): `glossario.json` com 11 termos + `glossario.schema.json` (JSON Schema draft-07) pra validação
- **Composable** (`useAcademiaGlossario.js`): carrega o JSON, valida termos (required fields, tipos, maxLength, categoria enum), checa nomes duplicados, agrupa por categoria e expõe busca case-insensitive
- **Component** (`academyTermCard.vue`): card com frente (nome + short) e verso expandido (long + exemplo), barra lateral colorida por categoria (teal/violet/amber), label da categoria na mesma cor da borda
- **Page** (`academy.vue`): `PageHeader`, `UInput` de busca ao vivo, seções por categoria (Conceito/8, Estratégia/2, Modelo/1), grid responsivo 1/2/3 colunas, tratamento de erro/empty
- **Nav**: link "Academia" no header (`i-lucide-graduation-cap`), ordem: Dashboard · Jogos do Dia · Apostas do Dia · Performance · Academia
- **DOX**: `app/data/AGENTS.md` criado, `app/pages/AGENTS.md` e `app/components/AGENTS.md` atualizados

## UX details

- Cards fechados com altura uniforme (`line-clamp-2` no short + `min-h-28`)
- `items-start` no grid: quando um card expande, os outros não esticam
- Transição suave de `max-height` + `opacity` na abertura/fechamento
- Busca filtra em `name + short + long` ao vivo (sem debounce, 11 termos é instantâneo)
- Categoria com 0 resultados após filtro some da tela
- Mensagem "Nenhum termo encontrado pra '...'" quando a busca não casa

## Tests

8 testes no `academyTermCard.spec.ts` (collapsed rendering, expand/collapse, 3 category colors, badge text). 46/46 testes no suite completo, sem regressão.

## Files changed

| File | Action |
|------|--------|
| `app/data/academia/glossario.schema.json` | Created |
| `app/data/academia/glossario.json` | Created |
| `app/data/AGENTS.md` | Created |
| `app/composables/useAcademiaGlossario.js` | Created |
| `app/components/academyTermCard.vue` | Created |
| `app/pages/academy.vue` | Created |
| `tests/app/components/academyTermCard.spec.ts` | Created |
| `app/layouts/default.vue` | Modified (nav link) |
| `app/pages/AGENTS.md` | Modified |
| `app/components/AGENTS.md` | Modified |
| `docs/superpowers/plans/2026-07-02-academy.md` | Created (plan) |