### PR TITLE
feat: performance - validação vs real + significância estatística

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,8 +117,9 @@ When the user requests a durable behavior change, record it here or in the relev
 - **Profit coloring**: teal-500 positive, red-500 negative
 - **No shadows**: depth via surface contrast only
 - **Chart plugins** registered client-only in `plugins/chartjs.client.js`
+- **Font sizes**: Tailwind v4 theme defines `text-2xs` (10px / 0.625rem) in `assets/css/main.css` for compact inline indicators. Use it instead of arbitrary `text-[10px]` (barred by lint).
 - **Number formatting**: dot decimal, no thousands separator. Use helpers from `app/utils/formatNumber.js`:
   - `formatUnit(n)` → `"<n>u"` for stake-unit values (profit, invested, win/loss médio, EV, max DD, accumulated, std dev, etc.) — the dashboard's framing is "stake = 1% da banca", so these are multiples of stake, not BRL
-  - `formatPercent(n)` → `"<n>%"` for percent fields (ROI, WR, Lucro efetivo)
-  - `formatNumber(n)` → bare number for odds (dimensionless), counts, and statistical scalars (R², Sharpe, slope — use raw `toFixed` for those)
+  - `formatPercent(n)` → `"<n>%"` for percent fields (ROI, WR, Lucro efetivo, Kelly Criterion, edge probability, IC limits)
+  - `formatNumber(n)` → bare number for odds (dimensionless), counts, and statistical scalars (R², Sharpe, slope, T-statistic, p-value — use raw `toFixed` for those)
   Do not use `toLocaleString('pt-BR')` or `toFixed(2)` for any of the above; reach for the helper.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -42,7 +42,7 @@ Main source directory for the DataPlay Bets Nuxt 4 application. Contains all fro
 
 | Path | Scope |
 |------|-------|
-| `components/` | 23 Vue components: cards, charts, tables, modals, skeletons |
+| `components/` | 25 Vue components: cards, charts, tables, modals, skeletons |
 | `composables/` | API layer (`useModelApi.js`) and chart options (`useChartOptions.js`) |
 | `pages/` | 4 pages: dashboard, fixtures, daily-bets, performance |
 | `utils/` | Helpers: lodash replacements, model name resolvers, date formatter |

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -4,6 +4,10 @@
 @theme {
   --font-sans: 'Plus Jakarta Sans', system-ui, sans-serif;
 
+  /* Extra small font size for compact comparison indicators */
+  --text-2xs: 0.625rem;
+  --text-2xs--line-height: 0.875rem;
+
   /* Colors - Canvas & Surface (zinc palette) */
   --color-canvas: #09090b;
   --color-surface-soft: #18181b;

--- a/app/components/metricComparison.vue
+++ b/app/components/metricComparison.vue
@@ -1,0 +1,63 @@
+<template>
+  <span
+    v-if="comparable && delta != null"
+    class="text-2xs inline-flex items-center font-medium"
+    :class="deltaClass"
+    :title="tooltipText"
+    :data-metric="def.key"
+  >
+    <UIcon :name="deltaIcon" class="h-3 w-3" />
+    {{ deltaLabel }}
+  </span>
+</template>
+
+<script setup>
+const props = defineProps({
+  def: {
+    type: Object,
+    required: true,
+  },
+  real: {
+    type: Number,
+    default: null,
+  },
+  val: {
+    type: Number,
+    default: null,
+  },
+})
+
+const comparable = computed(() => props.def.comparable && props.real != null && props.val != null)
+
+const delta = computed(() => {
+  if (!comparable.value) return null
+  return props.real - props.val
+})
+
+const deltaLabel = computed(() => {
+  if (delta.value == null) return ''
+  const factor = props.def.deltaFactor ?? 1
+  const formatted = formatNumber(delta.value * factor, 2)
+  const sign = delta.value > 0 ? '+' : ''
+  return `${sign}${formatted}${props.def.deltaUnit ?? ''}`
+})
+
+const deltaClass = computed(() => {
+  if (delta.value == null) return 'text-zinc-500'
+  if (delta.value > 0) return 'text-teal-400'
+  if (delta.value < 0) return 'text-red-400'
+  return 'text-zinc-500'
+})
+
+const deltaIcon = computed(() => {
+  if (delta.value == null) return 'i-lucide-minus'
+  if (delta.value > 0) return 'i-lucide-arrow-up'
+  if (delta.value < 0) return 'i-lucide-arrow-down'
+  return 'i-lucide-minus'
+})
+
+const tooltipText = computed(() => {
+  if (delta.value == null) return ''
+  return `Val: ${props.def.format(props.val)} · Real: ${props.def.format(props.real)}`
+})
+</script>

--- a/app/components/metricsCard.vue
+++ b/app/components/metricsCard.vue
@@ -20,6 +20,10 @@
           <p class="mt-1 text-xl font-semibold" :class="roiClass">
             {{ formatPercent(metricsData.roi) }}
           </p>
+
+          <div class="mt-0.5">
+            <MetricComparison :def="ROI_DEF" :real="normalized.roi" :val="normalizedCompare?.roi" />
+          </div>
         </div>
       </div>
 
@@ -27,7 +31,11 @@
         <div v-for="m in metrics" :key="m.label">
           <p class="text-xs font-medium tracking-wide text-zinc-500 uppercase">{{ m.label }}</p>
 
-          <p class="mt-0.5 text-sm font-medium text-white">{{ m.value }}</p>
+          <div class="mt-0.5 flex items-center gap-1">
+            <p class="text-sm font-medium text-white">{{ m.value }}</p>
+
+            <MetricComparison :def="m.def" :real="m.raw" :val="m.compareRaw" />
+          </div>
         </div>
       </div>
     </div>
@@ -44,35 +52,72 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  compareWith: {
+    type: Object,
+    default: null,
+  },
 })
 
-const lucroEfetivo = computed(() => {
-  if (props.metricsData.medLoss === 0) return 0
-  return (props.metricsData.ev / -props.metricsData.medLoss) * 100
-})
+function calcLucroEfetivo(m) {
+  if (!m || m.medLoss === 0) return 0
+  return (m.ev / -m.medLoss) * 100
+}
 
-const profitClass = computed(() => {
-  const v = props.metricsData.plb
+function normalizeMetrics(m) {
+  if (!m) return null
+  return {
+    plb: m.plb,
+    roi: m.roi,
+    wr: m.wr,
+    odds: m.odds,
+    medGain: m.medGain,
+    medLoss: m.medLoss,
+    ev: m.ev,
+    lucroEfetivo: calcLucroEfetivo(m),
+    dd: m.dd,
+    entradas: m.entradas,
+  }
+}
+
+const ROI_DEF = { key: 'roi', label: 'ROI', format: formatPercent, deltaUnit: 'pp', comparable: true }
+
+const METRIC_DEFS = [
+  {
+    key: 'wr',
+    label: 'WR',
+    format: (v) => formatPercent(v * 100, 0),
+    deltaUnit: 'pp',
+    deltaFactor: 100,
+    comparable: true,
+  },
+  { key: 'odds', label: 'Odd média', format: formatNumber, comparable: false },
+  { key: 'medGain', label: 'Win médio', format: formatUnit, deltaUnit: 'u', comparable: true },
+  { key: 'medLoss', label: 'Loss médio', format: formatUnit, deltaUnit: 'u', comparable: true },
+  { key: 'ev', label: 'EV', format: formatUnit, deltaUnit: 'u', comparable: true },
+  { key: 'lucroEfetivo', label: 'Lucro efetivo', format: formatPercent, deltaUnit: 'pp', comparable: true },
+  { key: 'dd', label: 'Máx DD', format: formatUnit, deltaUnit: 'u', comparable: true },
+  { key: 'entradas', label: 'Entradas', format: String, comparable: false },
+]
+
+const normalized = computed(() => normalizeMetrics(props.metricsData))
+const normalizedCompare = computed(() => normalizeMetrics(props.compareWith))
+
+function signClass(v) {
   if (v > 0) return 'text-teal-400'
   if (v < 0) return 'text-red-400'
   return 'text-white'
-})
+}
 
-const roiClass = computed(() => {
-  const v = props.metricsData.roi
-  if (v > 0) return 'text-teal-400'
-  if (v < 0) return 'text-red-400'
-  return 'text-white'
-})
+const profitClass = computed(() => signClass(props.metricsData.plb))
+const roiClass = computed(() => signClass(props.metricsData.roi))
 
-const metrics = computed(() => [
-  { label: 'WR', value: formatPercent(props.metricsData.wr * 100, 0) },
-  { label: 'Odd média', value: formatNumber(props.metricsData.odds) },
-  { label: 'Win médio', value: formatUnit(props.metricsData.medGain) },
-  { label: 'Loss médio', value: formatUnit(props.metricsData.medLoss) },
-  { label: 'EV', value: formatUnit(props.metricsData.ev) },
-  { label: 'Lucro efetivo', value: formatPercent(lucroEfetivo.value) },
-  { label: 'Máx DD', value: formatUnit(props.metricsData.dd) },
-  { label: 'Entradas', value: String(props.metricsData.entradas) },
-])
+const metrics = computed(() =>
+  METRIC_DEFS.map((def) => ({
+    label: def.label,
+    value: def.format(normalized.value[def.key]),
+    def,
+    raw: normalized.value[def.key],
+    compareRaw: normalizedCompare.value?.[def.key],
+  })),
+)
 </script>

--- a/app/components/performanceChartCard.vue
+++ b/app/components/performanceChartCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <UCard id="model-chart" class="order-1 border border-zinc-800 bg-zinc-900 lg:order-2 lg:col-span-7">
+  <UCard id="model-chart" class="order-1 border border-zinc-800 bg-zinc-900 xl:order-2 xl:col-span-7">
     <template #header>
       <div class="flex justify-between">
         <p class="font-semibold">Gráfico de acúmulo de capital</p>

--- a/app/components/statisticalSignificanceCard.vue
+++ b/app/components/statisticalSignificanceCard.vue
@@ -101,8 +101,8 @@ const metrics = computed(() => [
   },
   {
     label: LABELS.roiPValue,
-    value: formatNumber(s.value.roiPValue, 3),
-    class: (s.value.roiPValue || 1) < 0.05 ? 'text-teal-400' : 'text-red-400',
+    value: pValueDisplay(s.value.roiPValue),
+    class: (s.value.roiPValue ?? 1) < 0.05 ? 'text-teal-400' : 'text-red-400',
     key: 'roiPValue',
   },
   {
@@ -125,8 +125,8 @@ const metrics = computed(() => [
   },
   {
     label: LABELS.wrPValue,
-    value: formatNumber(s.value.wrPValue, 3),
-    class: (s.value.wrPValue || 1) < 0.05 ? 'text-teal-400' : 'text-red-400',
+    value: pValueDisplay(s.value.wrPValue),
+    class: (s.value.wrPValue ?? 1) < 0.05 ? 'text-teal-400' : 'text-red-400',
     key: 'wrPValue',
   },
   {
@@ -156,6 +156,14 @@ function edgeProbClass(v) {
   if (v > 80) return 'text-teal-400'
   if (v < 50) return 'text-red-400'
   return 'text-white'
+}
+
+function pValueDisplay(v) {
+  if (v == null) return '—'
+  if (v === 0) return '<0.001'
+  const formatted = formatNumber(v, 3)
+  if (formatted === '0.000') return '<0.001'
+  return formatted
 }
 
 function sampleSizeValue(min, remaining) {

--- a/app/components/statisticalSignificanceCard.vue
+++ b/app/components/statisticalSignificanceCard.vue
@@ -1,13 +1,15 @@
 <template>
   <UCard id="statistical-significance" class="border border-zinc-800 bg-zinc-900">
     <template #header>
-      <p class="font-semibold">Significância Estatística</p>
+      <p class="font-semibold">Significância estatística</p>
     </template>
 
     <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
       <div v-for="m in metrics" :key="m.label">
         <div class="flex items-center gap-1">
-          <p class="text-xs font-medium tracking-wide text-zinc-500 uppercase">{{ m.label }}</p>
+          <p class="text-xs font-medium tracking-wide text-zinc-500 uppercase">
+            {{ m.label }}
+          </p>
 
           <UButton
             v-if="m.key"
@@ -21,13 +23,17 @@
           />
         </div>
 
-        <p class="mt-1 text-base font-semibold" :class="m.class">{{ m.value }}</p>
+        <p class="mt-1 text-base font-semibold" :class="m.class">
+          {{ m.value }}
+        </p>
       </div>
     </div>
 
     <UModal v-for="m in infoMetrics" :key="m.label" v-model:open="infoOpen[m.key]" :title="m.label">
       <template #body>
-        <p class="text-sm leading-relaxed text-zinc-300">{{ m.text }}</p>
+        <p class="text-sm leading-relaxed text-zinc-300">
+          {{ m.text }}
+        </p>
       </template>
     </UModal>
   </UCard>
@@ -168,6 +174,7 @@ function pValueDisplay(v) {
 
 function sampleSizeValue(min, remaining) {
   if (min == null) return '—'
+  if (min >= 999999) return '>100.000'
   const base = formatNumber(min, 0)
   if (remaining == null || remaining === 0) return base
   return `${base} (${formatNumber(remaining, 0)} faltam)`

--- a/app/components/statisticalSignificanceCard.vue
+++ b/app/components/statisticalSignificanceCard.vue
@@ -1,0 +1,167 @@
+<template>
+  <UCard id="statistical-significance" class="border border-zinc-800 bg-zinc-900">
+    <template #header>
+      <p class="font-semibold">Significância Estatística</p>
+    </template>
+
+    <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
+      <div v-for="m in metrics" :key="m.label">
+        <div class="flex items-center gap-1">
+          <p class="text-xs font-medium tracking-wide text-zinc-500 uppercase">{{ m.label }}</p>
+
+          <UButton
+            v-if="m.key"
+            variant="ghost"
+            size="xs"
+            icon="i-lucide-info"
+            color="neutral"
+            :aria-label="`O que é ${m.label}?`"
+            class="-mt-0.5 cursor-pointer p-0 text-zinc-700 hover:text-zinc-400"
+            @click="infoOpen[m.key] = true"
+          />
+        </div>
+
+        <p class="mt-1 text-base font-semibold" :class="m.class">{{ m.value }}</p>
+      </div>
+    </div>
+
+    <UModal v-for="m in infoMetrics" :key="m.label" v-model:open="infoOpen[m.key]" :title="m.label">
+      <template #body>
+        <p class="text-sm leading-relaxed text-zinc-300">{{ m.text }}</p>
+      </template>
+    </UModal>
+  </UCard>
+</template>
+
+<script setup>
+const props = defineProps({
+  stats: {
+    type: Object,
+    default: null,
+  },
+})
+
+const LABELS = {
+  roiTStatistic: 'T-statistic ROI',
+  roiPValue: 'p-value ROI',
+  roiConfidenceInterval: 'IC 95% ROI',
+  positiveEdgeProbability: 'Prob. edge positivo',
+  wrTStatistic: 'T-statistic WR',
+  wrPValue: 'p-value WR',
+  kellyCriterion: 'Kelly Criterion',
+  minimumSampleSize: 'Amostra mínima',
+}
+
+const INFO_TEXT = {
+  roiTStatistic:
+    'Mede quantos desvios padrão o ROI observado está de zero. Valores absolutos maiores que 2 indicam significância estatística.',
+  roiPValue:
+    'Probabilidade de observar esse ROI se o modelo não tivesse edge de verdade. Valores abaixo de 0.05 (5%) indicam que o ROI é significativamente diferente de zero.',
+  roiConfidenceInterval:
+    'Intervalo de 95% de confiança para o ROI real do modelo. Se o intervalo não incluir zero, o edge é estatisticamente robusto.',
+  positiveEdgeProbability:
+    'Chance de o modelo ter edge lucrativo de verdade. Acima de 80% é verde; abaixo de 50% é vermelho.',
+  wrTStatistic:
+    'Testa se a taxa de acerto é maior que o breakeven implícito na odd média. Valores absolutos maiores que 2 indicam significância.',
+  wrPValue:
+    'Probabilidade de a taxa de acerto observada ocorrer por acaso se o modelo apenas quebrasse a paridade das odds.',
+  kellyCriterion:
+    'Fração ótima da banca a alocar em cada aposta do modelo, segundo o critério de Kelly. Valores negativos indicam que não se deve seguir o modelo.',
+  minimumSampleSize:
+    'Número mínimo de apostas necessário para detectar o ROI observado com 95% de confiança e 80% de poder estatístico.',
+}
+
+const infoOpen = reactive({
+  roiTStatistic: false,
+  roiPValue: false,
+  roiConfidenceInterval: false,
+  positiveEdgeProbability: false,
+  wrTStatistic: false,
+  wrPValue: false,
+  kellyCriterion: false,
+  minimumSampleSize: false,
+})
+
+const infoMetrics = computed(() =>
+  Object.entries(INFO_TEXT).map(([key, text]) => ({
+    label: LABELS[key],
+    text,
+    key,
+  })),
+)
+
+const s = computed(() => props.stats || {})
+
+const metrics = computed(() => [
+  {
+    label: LABELS.roiTStatistic,
+    value: formatNumber(s.value.roiTStatistic),
+    class: Math.abs(s.value.roiTStatistic || 0) > 2 ? 'text-teal-400' : 'text-red-400',
+    key: 'roiTStatistic',
+  },
+  {
+    label: LABELS.roiPValue,
+    value: formatNumber(s.value.roiPValue, 3),
+    class: (s.value.roiPValue || 1) < 0.05 ? 'text-teal-400' : 'text-red-400',
+    key: 'roiPValue',
+  },
+  {
+    label: LABELS.roiConfidenceInterval,
+    value: `${formatPercent(s.value.roiConfidenceInterval?.[0])} → ${formatPercent(s.value.roiConfidenceInterval?.[1])}`,
+    class: icClass(s.value.roiConfidenceInterval),
+    key: 'roiConfidenceInterval',
+  },
+  {
+    label: LABELS.positiveEdgeProbability,
+    value: formatPercent(s.value.positiveEdgeProbability, 1),
+    class: edgeProbClass(s.value.positiveEdgeProbability),
+    key: 'positiveEdgeProbability',
+  },
+  {
+    label: LABELS.wrTStatistic,
+    value: formatNumber(s.value.wrTStatistic),
+    class: Math.abs(s.value.wrTStatistic || 0) > 2 ? 'text-teal-400' : 'text-red-400',
+    key: 'wrTStatistic',
+  },
+  {
+    label: LABELS.wrPValue,
+    value: formatNumber(s.value.wrPValue, 3),
+    class: (s.value.wrPValue || 1) < 0.05 ? 'text-teal-400' : 'text-red-400',
+    key: 'wrPValue',
+  },
+  {
+    label: LABELS.kellyCriterion,
+    value: formatPercent(s.value.kellyCriterion, 2),
+    class: (s.value.kellyCriterion || 0) > 0 ? 'text-teal-400' : 'text-red-400',
+    key: 'kellyCriterion',
+  },
+  {
+    label: LABELS.minimumSampleSize,
+    value: sampleSizeValue(s.value.minimumSampleSize, s.value.sampleSizeRemaining),
+    class: (s.value.sampleSizeRemaining || 0) === 0 ? 'text-teal-400' : 'text-red-400',
+    key: 'minimumSampleSize',
+  },
+])
+
+function icClass(interval) {
+  if (!interval || interval.length !== 2) return 'text-white'
+  const [lower, upper] = interval
+  if (lower > 0) return 'text-teal-400'
+  if (upper < 0) return 'text-red-400'
+  return 'text-white'
+}
+
+function edgeProbClass(v) {
+  if (v == null) return 'text-white'
+  if (v > 80) return 'text-teal-400'
+  if (v < 50) return 'text-red-400'
+  return 'text-white'
+}
+
+function sampleSizeValue(min, remaining) {
+  if (min == null) return '—'
+  const base = formatNumber(min, 0)
+  if (remaining == null || remaining === 0) return base
+  return `${base} (${formatNumber(remaining, 0)} faltam)`
+}
+</script>

--- a/app/pages/performance/[[model]].vue
+++ b/app/pages/performance/[[model]].vue
@@ -37,7 +37,11 @@
         <div id="metrics-cards" class="order-2 flex flex-col gap-3 lg:order-1 lg:col-span-3">
           <MetricsCard :metrics-data="modelData.metrics.val" :card-title="'Métricas de validação'" />
 
-          <MetricsCard :metrics-data="modelData.metrics.real" :card-title="'Métricas de jogos reais'" />
+          <MetricsCard
+            :metrics-data="modelData.metrics.real"
+            :compare-with="modelData.metrics.val"
+            :card-title="'Métricas de jogos reais'"
+          />
         </div>
 
         <PerformanceChartCard
@@ -88,17 +92,11 @@ const playedOnSet = computed(() => {
 
 const chosenModel = ref(listModels.value[0] || null)
 
-if (
-  route.params.model &&
-  listModels.value.length &&
-  listModels.value.includes(route.params.model)
-) {
+if (route.params.model && listModels.value.length && listModels.value.includes(route.params.model)) {
   chosenModel.value = route.params.model
 }
 
-const chosenModelId = computed(() =>
-  chosenModel.value ? modelNameToIdName(chosenModel.value) : null,
-)
+const chosenModelId = computed(() => (chosenModel.value ? modelNameToIdName(chosenModel.value) : null))
 const chartByDay = ref(false)
 
 // --- Per-model data: each composable re-runs when chosenModelId changes ---

--- a/app/pages/performance/[[model]].vue
+++ b/app/pages/performance/[[model]].vue
@@ -33,8 +33,8 @@
     <DataErrorCard v-else-if="!modelData" message="Não foi possível carregar as métricas do modelo" />
 
     <template v-else>
-      <div class="grid w-full grid-cols-1 gap-3 lg:grid-cols-10">
-        <div id="metrics-cards" class="order-2 flex flex-col gap-3 lg:order-1 lg:col-span-3">
+      <div class="grid w-full grid-cols-1 gap-3 xl:grid-cols-10">
+        <div id="metrics-cards" class="order-2 flex flex-col gap-3 xl:order-1 xl:col-span-3">
           <MetricsCard :metrics-data="modelData.metrics.val" :card-title="'Métricas de validação'" />
 
           <MetricsCard

--- a/app/pages/performance/[[model]].vue
+++ b/app/pages/performance/[[model]].vue
@@ -52,6 +52,8 @@
         />
       </div>
 
+      <StatisticalSignificanceCard :stats="modelData.metrics.statisticalSignificance" />
+
       <BlockMetricsPanel :metrics-total="modelData.metrics.total" :blocks-history="modelData.blocksHistory" />
 
       <ResultsTablesGrid :monthly-results="monthlyResults" :daily-results="dailyResults" />

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,7 +19,7 @@ Unit tests for Vue components using Vitest + @nuxt/test-utils.
 ## Work Guidance
 
 - Test directory mirrors `app/` structure
-- 6 component tests exist (added metricsCard.spec.ts in this revision)
+- 8 component tests exist (added metricsCard.spec.ts in this revision)
 - Tests use `describe/it/expect` from Vitest
 - Components mounted with `mountSuspended()` for Nuxt integration
 
@@ -27,9 +27,13 @@ Unit tests for Vue components using Vitest + @nuxt/test-utils.
 | `betsTableCard.spec.ts` | Renders count, pagination button states, page emit |
 | `blockMetricsPanel.spec.ts` | Renders header, history sub-header, passes props |
 | `dailyBetCard.spec.ts` | Renders date badge, header, match split, 3 odds, container classes |
-| `metricsCard.spec.ts` | Renders title, formats PLB/ROI/WR/odds/EV/DD/entradas, profit/roi colour classes, lucroEfetivo (incl. medLoss=0 guard) |
+| `metricsCard.spec.ts` | Renders title, formats PLB/ROI/WR/odds/EV/DD/entradas, profit/roi colour classes, lucroEfetivo (incl. medLoss=0 guard), val-vs-real comparison indicators |
 | `performanceChartCard.spec.ts` | Renders header, switch, metric labels, modals, zoom reset, emit |
 
+
+| `academyTermCard.spec.ts` | Renders term card with title, definition, example, category badge |
+| `resultsTablesGrid.spec.ts` | Renders monthly and daily results tables with correct columns |
+| `statisticalSignificanceCard.spec.ts` | Renders 8 metrics, colours by significance (p-value, Kelly, edge prob), dashes when stats null |
 
 ## Verification
 

--- a/tests/app/components/metricsCard.spec.ts
+++ b/tests/app/components/metricsCard.spec.ts
@@ -179,4 +179,65 @@ describe('MetricsCard', () => {
     // (-0.05 / 1.0) * 100 = -5 -> "-5.00%"
     expect(wrapper.text()).toContain('-5.00%')
   })
+
+  it('does not render comparison indicators when compareWith is not provided', async () => {
+    const wrapper = await mountSuspended(MetricsCard, {
+      props: { metricsData: baseMetrics, cardTitle: 'x' },
+    })
+    expect(wrapper.findAll('[data-metric]').length).toBe(0)
+  })
+
+  it('renders a negative delta when real ROI is worse than validation ROI', async () => {
+    const real = { ...baseMetrics, roi: -0.05 }
+    const wrapper = await mountSuspended(MetricsCard, {
+      props: { metricsData: real, compareWith: baseMetrics, cardTitle: 'x' },
+    })
+    const text = wrapper.text()
+    expect(text).toContain('-10.05pp')
+    // Red = real is worse than validation.
+    const deltaSpan = wrapper.find('[data-metric="roi"]')
+    expect(deltaSpan.classes()).toContain('text-red-400')
+  })
+
+  it('renders a positive delta when real WR is better than validation WR', async () => {
+    const real = { ...baseMetrics, wr: 0.7 }
+    const val = { ...baseMetrics, wr: 0.65 }
+    const wrapper = await mountSuspended(MetricsCard, {
+      props: { metricsData: real, compareWith: val, cardTitle: 'x' },
+    })
+    const text = wrapper.text()
+    expect(text).toContain('+5.00pp')
+    // Green = real is better than validation.
+    const deltaSpan = wrapper.find('[data-metric="wr"]')
+    expect(deltaSpan.classes()).toContain('text-teal-400')
+  })
+
+  it('does not render comparison for PLB, Odd média, or Entradas', async () => {
+    const wrapper = await mountSuspended(MetricsCard, {
+      props: { metricsData: baseMetrics, compareWith: baseMetrics, cardTitle: 'x' },
+    })
+    const text = wrapper.text()
+    expect(text).toContain('Profit (PLB)')
+    expect(text).toContain('Odd média')
+    expect(text).toContain('Entradas')
+    // Only the 7 comparable metrics render a comparison indicator.
+    const comparisons = wrapper.findAll('[data-metric]')
+    expect(comparisons.length).toBe(7)
+  })
+
+  it('renders comparison for Loss médio and Máx DD using the less-negative-is-better rule', async () => {
+    const real = { ...baseMetrics, medLoss: -1.2, dd: -50.05 }
+    const val = { ...baseMetrics, medLoss: -1.0, dd: -24.78 }
+    const wrapper = await mountSuspended(MetricsCard, {
+      props: { metricsData: real, compareWith: val, cardTitle: 'x' },
+    })
+    const text = wrapper.text()
+    expect(text).toContain('-0.20u')
+    expect(text).toContain('-25.27u')
+    // Both deltas are negative (real is worse) -> red.
+    const lossSpan = wrapper.find('[data-metric="medLoss"]')
+    const ddSpan = wrapper.find('[data-metric="dd"]')
+    expect(lossSpan.classes()).toContain('text-red-400')
+    expect(ddSpan.classes()).toContain('text-red-400')
+  })
 })

--- a/tests/app/components/statisticalSignificanceCard.spec.ts
+++ b/tests/app/components/statisticalSignificanceCard.spec.ts
@@ -20,7 +20,7 @@ describe('StatisticalSignificanceCard', () => {
     const wrapper = await mountSuspended(StatisticalSignificanceCard, {
       props: { stats: baseStats },
     })
-    expect(wrapper.text()).toContain('Significância Estatística')
+    expect(wrapper.text()).toContain('Significância estatística')
   })
 
   it('renders all 8 metrics', async () => {

--- a/tests/app/components/statisticalSignificanceCard.spec.ts
+++ b/tests/app/components/statisticalSignificanceCard.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment nuxt
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import StatisticalSignificanceCard from '~/components/statisticalSignificanceCard.vue'
+
+const baseStats = {
+  roiTStatistic: -0.21,
+  roiPValue: 0.834,
+  roiConfidenceInterval: [-0.52, 0.42],
+  positiveEdgeProbability: 41.7,
+  wrTStatistic: 0.65,
+  wrPValue: 0.516,
+  kellyCriterion: -0.02,
+  minimumSampleSize: 3847,
+  sampleSizeRemaining: 2805,
+}
+
+describe('StatisticalSignificanceCard', () => {
+  it('renders the section title', async () => {
+    const wrapper = await mountSuspended(StatisticalSignificanceCard, {
+      props: { stats: baseStats },
+    })
+    expect(wrapper.text()).toContain('Significância Estatística')
+  })
+
+  it('renders all 8 metrics', async () => {
+    const wrapper = await mountSuspended(StatisticalSignificanceCard, {
+      props: { stats: baseStats },
+    })
+    const text = wrapper.text()
+    expect(text).toContain('T-statistic ROI')
+    expect(text).toContain('p-value ROI')
+    expect(text).toContain('IC 95% ROI')
+    expect(text).toContain('Prob. edge positivo')
+    expect(text).toContain('T-statistic WR')
+    expect(text).toContain('p-value WR')
+    expect(text).toContain('Kelly Criterion')
+    expect(text).toContain('Amostra mínima')
+  })
+
+  it('colors p-value red when above 0.05', async () => {
+    const wrapper = await mountSuspended(StatisticalSignificanceCard, {
+      props: { stats: baseStats },
+    })
+    const pValue = wrapper.findAll('p.text-base').find((el) => el.text() === '0.834')
+    expect(pValue).toBeDefined()
+    expect(pValue.classes()).toContain('text-red-400')
+  })
+
+  it('colors p-value green when below 0.05', async () => {
+    const wrapper = await mountSuspended(StatisticalSignificanceCard, {
+      props: { stats: { ...baseStats, roiPValue: 0.01 } },
+    })
+    const pValue = wrapper.findAll('p.text-base').find((el) => el.text() === '0.010')
+    expect(pValue).toBeDefined()
+    expect(pValue.classes()).toContain('text-teal-400')
+  })
+
+  it('colors Kelly red when negative or zero', async () => {
+    const wrapper = await mountSuspended(StatisticalSignificanceCard, {
+      props: { stats: baseStats },
+    })
+    const kelly = wrapper.findAll('p.text-base').find((el) => el.text() === '-0.02%')
+    expect(kelly).toBeDefined()
+    expect(kelly.classes()).toContain('text-red-400')
+  })
+
+  it('colors sample size green when no remaining samples are needed', async () => {
+    const wrapper = await mountSuspended(StatisticalSignificanceCard, {
+      props: { stats: { ...baseStats, sampleSizeRemaining: 0 } },
+    })
+    const sample = wrapper.findAll('p.text-base').find((el) => el.text() === '3847')
+    expect(sample).toBeDefined()
+    expect(sample.classes()).toContain('text-teal-400')
+  })
+
+  it('renders dashes when stats are null', async () => {
+    const wrapper = await mountSuspended(StatisticalSignificanceCard, {
+      props: { stats: null },
+    })
+    expect(wrapper.text()).toContain('—')
+  })
+})


### PR DESCRIPTION
## Resumo

Adiciona duas funcionalidades à tela de performance:

### 1. Comparativo validação vs real
- Indicadores de comparação (seta ↑↓ + delta) ao lado de cada métrica do card de jogos reais
- Métricas comparáveis: ROI, WR, Win médio, Loss médio, EV, Lucro efetivo, Máx DD
- Métricas sem comparação: PLB (depende de sample size), Odd média (depende do tipo de modelo), Entradas
- Breakpoint de empilhamento alterado de lg (1024px) para xl (1280px)
- Novo tamanho de fonte text-2xs (10px) no tema Tailwind

### 2. Significância Estatística
Nova seção na tela de performance com 8 métricas:
- T-statistic ROI / p-value ROI
- IC 95% ROI
- Probabilidade de edge positivo
- T-statistic WR / p-value WR
- Kelly Criterion (fórmula universal mean/variance, funciona para back e lay)
- Amostra mínima necessária

Cores por significância (verde quando significativo, vermelho quando não).
Tooltips explicativos em cada métrica.

### Backend (jonebet-api)
- Nova função compute_statistical_significance(bets) em ModelService.py
- Campo metrics.statisticalSignificance no response de /models/:id
- Dependência scipy==1.13.1 adicionada

### Bug fixes
- p-value 0.000 agora mostra <0.001 em vez de 0.000 (que parecia zero)
- p-value 0 não é mais vermelho (bug 0 || 1 = 1 em JS)
- Kelly Criterion usa fórmula universal em vez de back-bet simplificada
- Amostra mínima >999.999 mostra >100.000
